### PR TITLE
Adds ability to parse only components

### DIFF
--- a/src/Parser/DocumentParser.php
+++ b/src/Parser/DocumentParser.php
@@ -78,6 +78,8 @@ class DocumentParser extends AbstractParser
 
     private array $coreDirectives = [];
 
+    private bool $onlyComponents = false;
+
     public function __construct()
     {
         $this->componentParser = new ComponentParser();
@@ -159,6 +161,13 @@ class DocumentParser extends AbstractParser
     public function withoutCoreDirectives(): DocumentParser
     {
         $this->coreDirectives = [];
+
+        return $this;
+    }
+
+    public function onlyParseComponents(bool $onlyComponents = true): DocumentParser
+    {
+        $this->onlyComponents = $onlyComponents;
 
         return $this;
     }
@@ -301,7 +310,14 @@ class DocumentParser extends AbstractParser
             $customComponentPattern = '|'.implode('|', $customComponentPatterns);
         }
 
-        preg_match_all('/(@?{{--|@?{{{|@?{{|<\?php|<\?=|@?{!!|@+|<x-|<\/x-|<x:|<\/x:'.$customComponentPattern.')/m', $this->content, $bladeCandidates, PREG_OFFSET_CAPTURE);
+        $componentPattern = '<x-|<\/x-|<x:|<\/x:'.$customComponentPattern;
+        $generalBladePattern = '@?{{--|@?{{{|@?{{|<\?php|<\?=|@?{!!|@+|'.$componentPattern;
+
+        if ($this->onlyComponents) {
+            $generalBladePattern = $componentPattern;
+        }
+
+        preg_match_all('/('.$generalBladePattern.')/m', $this->content, $bladeCandidates, PREG_OFFSET_CAPTURE);
 
         if (! is_array($bladeCandidates) || count($bladeCandidates) != 2) {
             return;

--- a/tests/Parser/TagComponentsTest.php
+++ b/tests/Parser/TagComponentsTest.php
@@ -5,6 +5,7 @@ namespace Stillat\BladeParser\Tests\Parser;
 use Stillat\BladeParser\Nodes\Components\ComponentNode;
 use Stillat\BladeParser\Nodes\Components\ParameterNode;
 use Stillat\BladeParser\Nodes\Components\ParameterType;
+use Stillat\BladeParser\Nodes\LiteralNode;
 use Stillat\BladeParser\Tests\ParserTestCase;
 
 class TagComponentsTest extends ParserTestCase
@@ -421,5 +422,20 @@ EOT;
         $this->assertSame('::class', $paramOne->name);
         $this->assertSame(':class', $paramOne->materializedName);
         $this->assertSame(ParameterType::EscapedParameter, $paramOne->type);
+    }
+
+    public function testParserCanBeConfiguredToOnlyParseComponents()
+    {
+        $template = <<<'EOT'
+<x-alert>
+    {{ $title }} @if ($this) @endif
+</x-alert>
+EOT;
+        $nodes = $this->parser()->onlyParseComponents()->parse($template);
+
+        $this->assertCount(3, $nodes);
+        $this->assertInstanceOf(ComponentNode::class, $nodes[0]);
+        $this->assertInstanceOf(LiteralNode::class, $nodes[1]);
+        $this->assertInstanceOf(ComponentNode::class, $nodes[2]);
     }
 }


### PR DESCRIPTION
This PR adds the ability to selectively parse only the components within a template when working with the `DocumentParser`, simplifying workloads that only require components:

```php
<?php

use Stillat\BladeParser\Parser\DocumentParser;
use Stillat\BladeParser\Document\Document;

$parser = new DocumentParser;

$template = <<<'BLADE'
<x-alert>
    {{ $title }} @if ($this) @endif
</x-alert>
BLADE;

// Only the components are parsed.
$parser->onlyParseComponents()->parse($template);

// To construct a Document instance and resolve tag pairs, we may use `syncFromParser`
$document = new Document;
$document->syncFromParser($parser)->resolveStructures();

```