### PR TITLE
Adds new getArgValues method

### DIFF
--- a/src/Compiler/CompilerServices/ArgStringSplitter.php
+++ b/src/Compiler/CompilerServices/ArgStringSplitter.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Stillat\BladeParser\Compiler\CompilerServices;
+
+use Stillat\BladeParser\Parser\AbstractParser;
+
+class ArgStringSplitter extends AbstractParser
+{
+    private function resetState(): void
+    {
+        $this->content = '';
+        $this->chars = [];
+        $this->currentContent = [];
+    }
+
+    protected function skipToEndOfPairedStructure(string $structureStart, string $structureEnd)
+    {
+        $structureCount = 0;
+
+        for ($this->currentIndex; $this->currentIndex < $this->inputLen; $this->currentIndex++) {
+            $this->checkCurrentOffsets();
+
+            if ($this->isStartingString()) {
+                $this->skipToEndOfString();
+
+                continue;
+            }
+
+            if ($this->cur == $structureStart) {
+                $structureCount++;
+            } elseif ($this->cur == $structureEnd) {
+                $structureCount--;
+            }
+
+            $this->currentContent[] = $this->cur;
+
+            if ($structureCount <= 0) {
+                break;
+            }
+        }
+    }
+
+    private function isBreakableWhitespace(?string $char): bool
+    {
+        if ($char == ',') {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function split(string $input): array
+    {
+        $this->resetState();
+
+        $this->content = $input;
+        $this->inputLen = mb_strlen($this->content);
+        $this->chunkSize = $this->inputLen;
+        $this->prepareParseAt(0);
+
+        $results = [];
+
+        for ($this->currentIndex; $this->currentIndex < $this->inputLen; $this->currentIndex++) {
+            $this->checkCurrentOffsets();
+
+            if ($this->isStartingString()) {
+                $this->skipToEndOfString();
+
+                if ($this->isBreakableWhitespace($this->next) || $this->next == null) {
+                    if (count($this->currentContent) > 0) {
+                        $results[] = trim(implode('', $this->currentContent));
+                        $this->currentContent = [];
+
+                        continue;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($this->cur == '[') {
+                $this->skipToEndOfPairedStructure('[', ']');
+
+                if ($this->isBreakableWhitespace($this->next) || $this->next == null) {
+                    if (count($this->currentContent) > 0) {
+                        $results[] = trim(implode('', $this->currentContent));
+                        $this->currentContent = [];
+
+                        continue;
+                    }
+                }
+
+                continue;
+            } elseif ($this->cur == '(') {
+                $this->skipToEndOfPairedStructure('(', ')');
+
+                if ($this->isBreakableWhitespace($this->next) || $this->next == null) {
+                    if (count($this->currentContent) > 0) {
+                        $results[] = trim(implode('', $this->currentContent));
+                        $this->currentContent = [];
+
+                        continue;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($this->isBreakableWhitespace($this->next) || $this->next == null) {
+                if (count($this->currentContent) > 0) {
+                    $this->currentContent[] = $this->cur;
+                    $results[] = trim(implode('', $this->currentContent));
+                    $this->currentContent = [];
+
+                    continue;
+                }
+            }
+
+            if ($this->isBreakableWhitespace($this->cur)) {
+                continue;
+            }
+
+            $this->currentContent[] = $this->cur;
+        }
+
+        return $results;
+    }
+}

--- a/src/Nodes/ArgumentGroupNode.php
+++ b/src/Nodes/ArgumentGroupNode.php
@@ -4,6 +4,7 @@ namespace Stillat\BladeParser\Nodes;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Stillat\BladeParser\Compiler\CompilerServices\ArgStringSplitter;
 use Stillat\BladeParser\Compiler\CompilerServices\StringSplitter;
 use Stillat\BladeParser\Compiler\CompilerServices\StringUtilities;
 
@@ -84,6 +85,15 @@ class ArgumentGroupNode extends AbstractNode
             // Remove the trailing ','
             return mb_substr(rtrim($value), 0, -1);
         });
+    }
+
+    public function getArgValues(): Collection
+    {
+        if ($this->contentType == ArgumentContentType::Json) {
+            return collect([$this->innerContent]);
+        }
+
+        return collect((new ArgStringSplitter())->split($this->innerContent));
     }
 
     public function clone(?DirectiveNode $newOwner = null): ArgumentGroupNode

--- a/tests/CompilerServices/ArgStringSplitterTest.php
+++ b/tests/CompilerServices/ArgStringSplitterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Stillat\BladeParser\Tests\CompilerServices;
+
+use Stillat\BladeParser\Compiler\CompilerServices\ArgStringSplitter;
+use Stillat\BladeParser\Tests\ParserTestCase;
+
+class ArgStringSplitterTest extends ParserTestCase
+{
+    protected ArgStringSplitter $splitter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->splitter = new ArgStringSplitter();
+    }
+
+    public function testArgumentStringSplitting()
+    {
+        $input = <<<'EOT'
+["one, two", $var1, $var2], $hello, 12345.23, bar, baz, (1,2,3,4,), "foo, bar, baz"
+EOT;
+
+        $this->assertSame([
+            '["one, two", $var1, $var2]',
+            '$hello',
+            '12345.23',
+            'bar',
+            'baz',
+            '(1,2,3,4,)',
+            '"foo, bar, baz"',
+        ], $this->splitter->split($input));
+
+        $input = <<<'EOT'
+[["one, two", $var1, $var2], $hello, 12345.23, bar, baz, (1,2,3,4,), "foo, bar, baz"]
+EOT;
+
+        $this->assertSame([
+            $input,
+        ], $this->splitter->split($input));
+
+        $input = <<<'EOT'
+(["one, two", $var1, $var2], $hello, 12345.23, bar, baz, (1,2,3,4,), "foo, bar, baz")
+EOT;
+
+        $this->assertSame([
+            $input,
+        ], $this->splitter->split($input));
+
+        $input = <<<'EOT'
+[["one, two", $var1, $var2], $hello, 12345.23], bar, baz, (1,2,3,4,), "foo, bar, baz"
+EOT;
+
+        $this->assertSame([
+            '[["one, two", $var1, $var2], $hello, 12345.23]',
+            'bar',
+            'baz',
+            '(1,2,3,4,)',
+            '"foo, bar, baz"',
+        ], $this->splitter->split($input));
+
+        $input = <<<'EOT'
+[["one, two", $var1, $var2], $hello, 12345.23], [bar, baz, (1,2,3,4,), "foo, bar, baz"]
+EOT;
+
+        $this->assertSame([
+            '[["one, two", $var1, $var2], $hello, 12345.23]',
+            '[bar, baz, (1,2,3,4,), "foo, bar, baz"]',
+        ], $this->splitter->split($input));
+
+        $input = <<<'EOT'
+[[[[[["one, two", $var1, $var2], $hello, 12345.23]]]]], [bar, baz, (1,2,3,4,), "foo, bar, baz"]
+EOT;
+
+        $this->assertSame([
+            '[[[[[["one, two", $var1, $var2], $hello, 12345.23]]]]]',
+            '[bar, baz, (1,2,3,4,), "foo, bar, baz"]',
+        ], $this->splitter->split($input));
+
+        $input = <<<'EOT'
+[[[[[["one, two", $var1, $var2], $hello, 12345.23]]]]], [bar, baz, (1,2,3,4,), "foo, bar, baz"], (true == false) ? $this : $that
+EOT;
+
+        $this->assertSame([
+            '[[[[[["one, two", $var1, $var2], $hello, 12345.23]]]]]',
+            '[bar, baz, (1,2,3,4,), "foo, bar, baz"]',
+            '(true == false) ? $this : $that',
+        ], $this->splitter->split($input));
+    }
+}


### PR DESCRIPTION
This PR adds a new `getArgValues` helper method to the `ArgumentGroupNode` node. This is similar to the existing `getValues()` utility method, but is smarter about how it breaks argument strings:

```php
<?php

use Stillat\BladeParser\Document\Document;
use Stillat\BladeParser\Document\DocumentCompilerOptions;

$template = <<<'BLADE'
    @js(["one, two", $var1, $var2], $hello, 12345.23, bar, baz, (1,2,3,4,), "foo, bar, baz")
BLADE;

$doc = Document::fromText($template);

// Smartly split the argument string.
$doc->findDirectiveByName('js')
    ->arguments->getArgValues();
```

The above sample would produce output similar to the following:

```
Illuminate\Support\Collection {#2538
  all: [
    "["one, two", $var1, $var2]",
    "$hello",
    "12345.23",
    "bar",
    "baz",
    "(1,2,3,4,)",
    ""foo, bar, baz"",
  ],
}
```