### PR TITLE
Adds Node Transformation Helper Utilities

### DIFF
--- a/src/Compiler/Transformers/NodeTransformer.php
+++ b/src/Compiler/Transformers/NodeTransformer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Stillat\BladeParser\Compiler\Transformers;
+
+use Stillat\BladeParser\Document\Document;
+use Stillat\BladeParser\Nodes\AbstractNode;
+
+abstract class NodeTransformer
+{
+    private ?AbstractNode $skipNode = null;
+
+    public function transformDocument(Document $document): string
+    {
+        return $this->transformNodes($document->getNodeArray());
+    }
+
+    public function transformNodes(array $nodes): string
+    {
+        $result = '';
+
+        foreach ($nodes as $node) {
+            if ($this->skipNode != null) {
+                if ($this->skipNode == $node) {
+                    $this->skipNode = null;
+                }
+
+                continue;
+            }
+
+            $nodeResult = $this->transformNode($node);
+
+            if ($nodeResult !== null) {
+                $result .= $nodeResult;
+
+                continue;
+            }
+
+            $result .= (string) $node;
+        }
+
+        return $result;
+    }
+
+    public function skipToNode(AbstractNode $node): void
+    {
+        $this->skipNode = $node;
+    }
+
+    abstract public function transformNode($node): ?string;
+}

--- a/src/Document/Document.php
+++ b/src/Document/Document.php
@@ -310,10 +310,22 @@ class Document
      * @param  string  $document The template content.
      * @param  string|null  $filePath An optional file path.
      * @param  string[]  $customComponentTags A list of custom component tag names.
+     * @param  DocumentOptions|null  $documentOptions Custom document options, if any.
      */
-    public static function fromText(string $document, ?string $filePath = null, array $customComponentTags = []): Document
+    public static function fromText(string $document, ?string $filePath = null, array $customComponentTags = [], ?DocumentOptions $documentOptions = null): Document
     {
         $parser = DocumentParserFactory::makeDocumentParser();
+
+        if ($documentOptions) {
+            if (! $documentOptions->withCoreDirectives) {
+                $parser->withoutCoreDirectives();
+            }
+
+            if (count($documentOptions->customDirectives) > 0) {
+                $parser->setDirectiveNames($documentOptions->customDirectives);
+            }
+        }
+
         $parser->registerCustomComponentTags($customComponentTags);
         $parser->parse($document);
 

--- a/src/Document/DocumentOptions.php
+++ b/src/Document/DocumentOptions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Stillat\BladeParser\Document;
+
+class DocumentOptions
+{
+    public function __construct(
+        /**
+         * Determines if core Laravel Blade directives should be parsed.
+         */
+        public bool $withCoreDirectives = true,
+        /**
+         * A list of custom directive names to parse.
+         *
+         * @var string[] $customDirectives
+         */
+        public array $customDirectives = [],
+    ) {
+    }
+}

--- a/tests/Compiler/NodeTransformerTest.php
+++ b/tests/Compiler/NodeTransformerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Stillat\BladeParser\Tests\Compiler;
+
+use Stillat\BladeParser\Compiler\Transformers\NodeTransformer;
+use Stillat\BladeParser\Document\Document;
+use Stillat\BladeParser\Document\DocumentOptions;
+use Stillat\BladeParser\Nodes\DirectiveNode;
+use Stillat\BladeParser\Tests\ParserTestCase;
+
+class NodeTransformerTest extends ParserTestCase
+{
+    private function transform(string $template): string
+    {
+        $doc = Document::fromText($template, documentOptions: new DocumentOptions(
+            withCoreDirectives: false,
+            customDirectives: ['custom', 'endcustom']
+        ))->resolveStructures();
+
+        return (new CustomTransformer())->transformDocument($doc);
+    }
+
+    public function testNodeTransformerCanTransformSimpleNodes()
+    {
+        $blade = <<<'BLADE'
+The beginning.
+
+@custom
+    Hello, world!
+@endcustom
+
+The end.
+BLADE;
+
+        $result = $this->transform($blade);
+
+        $expected = <<<'EXPECTED'
+The beginning.
+
+@include("something-here")
+
+The end.
+EXPECTED;
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider templateProvider
+     */
+    public function testNodeTransformerCanTransformNodes($template)
+    {
+        $insert = <<<'BLADE'
+
+@custom
+    Hello, world!
+@endcustom
+
+BLADE;
+
+        $insertExpected = <<<'BLADE'
+
+@include("something-here")
+
+BLADE;
+
+        $blade = $template.$insert.$template;
+        $expected = $template.$insertExpected.$template;
+
+        $this->assertSame($expected, $this->transform($blade));
+    }
+
+    public function templateProvider(): array
+    {
+        $templates = [
+            '@if (true) something @endif',
+            '@if (true) @if (false) Hello! @endif @endif',
+            'Some text
+@verbatim
+    {{ $a }}
+    @if($b)
+        {{ $b }}
+    @endif
+@endverbatim',
+            '@for ($i = 0; $i < 10; $i++)
+test
+@break
+@endfor',
+            '@for ($i = 0; $i < 10; $i++)
+test
+@break(-2)
+@endfor',
+            <<<'BLADE'
+@cannot ('update', [$post])
+breeze
+@elsecannot('delete', [$post])
+sneeze
+@endcannot
+BLADE,
+            '{{-- this is a comment --}}',
+            '@componentFirst(["one", "two"])',
+            '<x-slot name="foo"></x-slot>',
+            '@for ($i = 0; $i < 10; $i++)
+test
+@continue(TRUE)
+@endfor',
+            '{{ $name }}',
+            '@{{ $name }}',
+            '@verbatim {{ $a }} @endverbatim {{ $b }} @verbatim {{ $c }} @endverbatim',
+            '@php echo "#1"; @endphp @verbatim {{ #2 }} @endverbatim @verbatim {{ #3 }} @endverbatim @php echo "#4"; @endphp',
+            '{{ $first }}
+@php
+    echo $second;
+@endphp
+@if ($conditional)
+    {{ $third }}
+@endif
+@include("users")
+@verbatim
+    {{ $fourth }} @include("test")
+@endverbatim
+@php echo $fifth; @endphp',
+            '{{-- @verbatim Block #1 @endverbatim --}} @php "Block #2" @endphp',
+            '@forelse ($this->getUsers() as $user)
+breeze
+@empty
+empty
+@endforelse',
+            '<?php echo "Hello, world!"; ?>',
+            '@php ($var = "Hello, world!")',
+        ];
+        $templatesToTest = [];
+        $bigTemplate = '';
+
+        foreach ($templates as $template) {
+            $template = "\n".$template."\n";
+            $templatesToTest[] = [$template];
+            $bigTemplate .= $template;
+
+            if ($template != $bigTemplate) {
+                $templatesToTest[] = [$bigTemplate];
+            }
+        }
+
+        return $templatesToTest;
+    }
+}
+
+class CustomTransformer extends NodeTransformer
+{
+    public function transformNode($node): ?string
+    {
+        if (! $node instanceof DirectiveNode || $node->content != 'custom') {
+            return null;
+        }
+
+        $this->skipToNode($node->isClosedBy);
+
+        return '@include("something-here")';
+    }
+}


### PR DESCRIPTION
This PR introduces a new abstract node transformer. This transformer provides a simple way to iterate all nodes in a document and change the output, while skipping over nodes within the document.

For example, if we had the following node transformer implementation:

```php
<?php

use Stillat\BladeParser\Compiler\Transformers\NodeTransformer;
use Stillat\BladeParser\Nodes\DirectiveNode;

class CustomTransformer extends NodeTransformer
{
    public function transformNode($node): ?string
    {
        if (! $node instanceof DirectiveNode || $node->content != 'custom') {
            return null;
        }

        $this->skipToNode($node->isClosedBy);

        return '@include("something-here")';
    }
}
```

we could transform a document like so:

```php
<?php

use Stillat\BladeParser\Document\Document;
use Stillat\BladeParser\Document\DocumentOptions;

$doc = Document::fromText($template, documentOptions: new DocumentOptions(
            withCoreDirectives: false,
            customDirectives: ['custom', 'endcustom']
        ))->resolveStructures();

$result = (new CustomTransformer())->transformDocument($doc);
```

to produce the final result:

```blade
The beginning.

@include("something-here")

The end.
```