### PR TITLE
Ensures json directive can compile complex expressions

### DIFF
--- a/src/Compiler/Concerns/CompilesJson.php
+++ b/src/Compiler/Concerns/CompilesJson.php
@@ -17,7 +17,7 @@ trait CompilesJson
     #[CompilesDirective(StructureType::EchoHelper, ArgumentRequirement::Required)]
     protected function compileJson(DirectiveNode $node): string
     {
-        $parts = explode(',', $this->getDirectiveArgsInnerContent($node));
+        $parts = $node->arguments?->getArgValues() ?? [''];
 
         $options = isset($parts[1]) ? trim($parts[1]) : $this->encodingOptions;
 

--- a/tests/Compiler/BladeJsonTest.php
+++ b/tests/Compiler/BladeJsonTest.php
@@ -24,9 +24,9 @@ class BladeJsonTest extends ParserTestCase
 
     public function testComplexJsonExpressionsCanBeCompiled()
     {
-        $string = 'var foo @json(DB::query()->selectRaw("1, CONCAT(2, \' \', 3) AS name")->get())';
+        $string = 'var foo = @json(DB::query()->selectRaw("1, CONCAT(2, \' \', 3) AS name")->get())';
         $expected = <<<'EXPECTED'
-var foo <?php echo json_encode(DB::query()->selectRaw("1, CONCAT(2, ' ', 3) AS name")->get(), 15, 512) ?>
+var foo = <?php echo json_encode(DB::query()->selectRaw("1, CONCAT(2, ' ', 3) AS name")->get(), 15, 512) ?>
 EXPECTED;
 
         $this->assertEquals($expected, $this->compiler->compileString($string));

--- a/tests/Compiler/BladeJsonTest.php
+++ b/tests/Compiler/BladeJsonTest.php
@@ -21,4 +21,14 @@ class BladeJsonTest extends ParserTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testComplexJsonExpressionsCanBeCompiled()
+    {
+        $string = 'var foo @json(DB::query()->selectRaw("1, CONCAT(2, \' \', 3) AS name")->get())';
+        $expected = <<<'EXPECTED'
+var foo <?php echo json_encode(DB::query()->selectRaw("1, CONCAT(2, ' ', 3) AS name")->get(), 15, 512) ?>
+EXPECTED;
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This PR improves the compiler support for the `@json` Blade directive.