### PR TITLE
Improves document validator; corrects issues with component tag compilation

### DIFF
--- a/src/Compiler/AppendState.php
+++ b/src/Compiler/AppendState.php
@@ -7,10 +7,10 @@ use Stillat\BladeParser\Nodes\AbstractNode;
 class AppendState
 {
     /**
-     * @param  AbstractNode  $node The node that was compiled.
-     * @param  int  $beforeLineNumber The last line number in the compiled document before the node was compiled.
-     * @param  int  $afterLineNumber The last line number in the compiled document after the node was compiled.
-     * @param  string  $value The node's compiled value.
+     * @param  AbstractNode  $node  The node that was compiled.
+     * @param  int  $beforeLineNumber  The last line number in the compiled document before the node was compiled.
+     * @param  int  $afterLineNumber  The last line number in the compiled document after the node was compiled.
+     * @param  string  $value  The node's compiled value.
      */
     public function __construct(public AbstractNode $node,
         public int $beforeLineNumber,

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -143,6 +143,8 @@ class Compiler
      */
     private bool $failStrictly = false;
 
+    private array $ignoreDirectives = [];
+
     public function __construct(DocumentParser $parser)
     {
         $this->compilationBuffer = new StringBuffer();
@@ -155,14 +157,23 @@ class Compiler
         );
     }
 
+    public function ignoreDirectives(array $directives): Compiler
+    {
+        $this->ignoreDirectives = $directives;
+        $this->componentTagCompiler->ignoreDirectives($directives);
+        $this->parser->ignoreDirectives($directives);
+
+        return $this;
+    }
+
     /**
      * Register a custom component tag compiler.
      *
      * This method will automatically register the provided tag name
      * with the component tag compiler.
      *
-     * @param  string  $tagName The custom component tag prefix.
-     * @param  CustomComponentTagCompiler  $compiler The compiler instance.
+     * @param  string  $tagName  The custom component tag prefix.
+     * @param  CustomComponentTagCompiler  $compiler  The compiler instance.
      * @return $this
      */
     public function registerCustomComponentTagCompiler(string $tagName, CustomComponentTagCompiler $compiler): Compiler
@@ -188,7 +199,7 @@ class Compiler
      * When set to false, the internal component tag compiler will
      * not compile Laravel component tags (<x-, <x:, etc.).
      *
-     * @param  bool  $compileCoreComponents Whether to compile core Laravel component tags.
+     * @param  bool  $compileCoreComponents  Whether to compile core Laravel component tags.
      * @return $this
      */
     public function setCompileCoreComponents(bool $compileCoreComponents): Compiler
@@ -232,7 +243,7 @@ class Compiler
      *
      * Callbacks are invoked in the order they were registered.
      *
-     * @param  callable  $callback The callback.
+     * @param  callable  $callback  The callback.
      * @return $this
      */
     public function onAppend(callable $callback): Compiler
@@ -273,7 +284,7 @@ class Compiler
      * `Stillat\BladeParser\Errors\Exceptions\CompilationException`
      * whenever it encounters a parser error.
      *
-     * @param  bool  $failOnParserErrors Whether to fail on parser errors.
+     * @param  bool  $failOnParserErrors  Whether to fail on parser errors.
      * @return $this
      */
     public function setFailOnParserErrors(bool $failOnParserErrors): Compiler
@@ -297,7 +308,7 @@ class Compiler
      * When set to true, the compiler will fail on any error type. When
      * set to false, it will only fail on fatal errors.
      *
-     * @param  bool  $isParserErrorsStrict Whether to fail on any parser error.
+     * @param  bool  $isParserErrorsStrict  Whether to fail on any parser error.
      * @return $this
      */
     public function setParserErrorsIsStrict(bool $isParserErrorsStrict): Compiler
@@ -324,7 +335,7 @@ class Compiler
      * In default setups, this is set to the return value of
      * `Illuminate\View\Compilers\BladeCompiler::getExtensions()`
      *
-     * @param  array  $extensions The extensions.
+     * @param  array  $extensions  The extensions.
      */
     public function setExtensions(array $extensions): Compiler
     {
@@ -339,7 +350,7 @@ class Compiler
      * In default setups, this is set to the return value of
      * `Illuminate\View\Compilers\BladeCompiler::getAnonymousComponentNamespaces()`
      *
-     * @param  array  $anonymousNamespaces The anonymous namespaces.
+     * @param  array  $anonymousNamespaces  The anonymous namespaces.
      */
     public function setAnonymousComponentNamespaces(array $anonymousNamespaces): Compiler
     {
@@ -355,7 +366,7 @@ class Compiler
      * In default setups, this is set to the return value of
      * `Illuminate\View\Compilers\BladeCompiler::getClassComponentAliases()`
      *
-     * @param  array  $aliases The class component aliases.
+     * @param  array  $aliases  The class component aliases.
      */
     public function setClassComponentAliases(array $aliases): Compiler
     {
@@ -371,7 +382,7 @@ class Compiler
      * In default setups, this is set to the return value of
      * `Illuminate\View\Compilers\BladeCompiler::getClassComponentNamespaces()`
      *
-     * @param  array  $namespaces The class component namespaces.
+     * @param  array  $namespaces  The class component namespaces.
      */
     public function setClassComponentNamespaces(array $namespaces): Compiler
     {
@@ -387,7 +398,7 @@ class Compiler
      * In default setups, this is set to the return value of
      * `Illuminate\View\Compilers\BladeCompiler::getAnonymousComponentPaths()`
      *
-     * @param  array  $paths The anonymous component paths.
+     * @param  array  $paths  The anonymous component paths.
      */
     public function setAnonymousComponentPaths(array $paths): Compiler
     {
@@ -408,7 +419,7 @@ class Compiler
     /**
      * Sets whether the compiler will fail when it encounters unknown component classes.
      *
-     * @param  bool  $doThrow Whether to throw on unknown component classes.
+     * @param  bool  $doThrow  Whether to throw on unknown component classes.
      */
     public function setThrowExceptionOnUnknownComponentClass(bool $doThrow): void
     {
@@ -418,7 +429,7 @@ class Compiler
     /**
      * Sets whether to compile class component tags.
      *
-     * @param  bool  $compilesComponentTags Whether to compile component tags.
+     * @param  bool  $compilesComponentTags  Whether to compile component tags.
      */
     public function setCompilesComponentTags(bool $compilesComponentTags): Compiler
     {
@@ -438,7 +449,7 @@ class Compiler
     /**
      * Sets the internal compilation target.
      *
-     * @param  CompilationTarget  $compilationTarget The compilation target.
+     * @param  CompilationTarget  $compilationTarget  The compilation target.
      */
     public function setCompilationTarget(CompilationTarget $compilationTarget): Compiler
     {
@@ -454,7 +465,7 @@ class Compiler
      * `Illuminate\View\Compilers\BladeCompiler::$conditions`
      * protected property.
      *
-     * @param  array  $conditions The condition handlers.
+     * @param  array  $conditions  The condition handlers.
      */
     public function setConditions(array $conditions): Compiler
     {
@@ -479,7 +490,7 @@ class Compiler
      * *not* need to manually call this method to sync compiler information
      * if you use the default compiler factory methods/service bindings.
      *
-     * @param  callable  $precompiler The precompiler.
+     * @param  callable  $precompiler  The precompiler.
      */
     public function precompiler(callable $precompiler): void
     {
@@ -494,7 +505,7 @@ class Compiler
      * *not* need to manually call this method to sync compiler information
      * if you use the default compiler factory methods/service bindings.
      *
-     * @param  string  $format The format to use.
+     * @param  string  $format  The format to use.
      */
     public function setEchoFormat(string $format): void
     {
@@ -560,7 +571,7 @@ class Compiler
      * `Illuminate\View\Compilers\BladeCompiler::$precompilers`
      * protected property.
      *
-     * @param  array  $precompilers The precompilers.
+     * @param  array  $precompilers  The precompilers.
      */
     public function setPrecompilers(array $precompilers): void
     {
@@ -592,7 +603,7 @@ class Compiler
     /**
      * Compile the given Blade template contents.
      *
-     * @param  string  $template The template.
+     * @param  string  $template  The template.
      *
      * @throws Exception
      * @throws UnsupportedNodeException
@@ -746,6 +757,10 @@ class Compiler
 
         $compiled = (string) $this->compilationBuffer;
 
+        // Normalize first.
+        $compiled = str_replace("\r\n", "\n", $compiled);
+
+        // Then, replace line endings with the desired ending.
         $compiled = str_replace("\n", $lineEnding, $compiled);
 
         if (count($this->footer) > 0) {
@@ -785,7 +800,7 @@ class Compiler
     /**
      * Execute user defined extensions.
      *
-     * @param  string  $value The value to compile.
+     * @param  string  $value  The value to compile.
      */
     protected function compileExtensions(string $value): string
     {
@@ -799,7 +814,7 @@ class Compiler
     /**
      * Add the stored footers to the compiled template.
      *
-     * @param  string  $result The compiled template.
+     * @param  string  $result  The compiled template.
      */
     protected function addFooters(string $result): string
     {

--- a/src/Compiler/CompilerServices/DirectiveNameValidator.php
+++ b/src/Compiler/CompilerServices/DirectiveNameValidator.php
@@ -7,7 +7,7 @@ class DirectiveNameValidator
     /**
      * Tests if the provided directive name is valid.
      *
-     * @param  string  $name The directive name.
+     * @param  string  $name  The directive name.
      */
     public static function isNameValid(string $name): bool
     {

--- a/src/Compiler/CompilerServices/LiteralContentHelpers.php
+++ b/src/Compiler/CompilerServices/LiteralContentHelpers.php
@@ -7,7 +7,7 @@ class LiteralContentHelpers
     /**
      * Reverses Blade literal content escape sequences in the provided content.
      *
-     * @param  string  $content The content.
+     * @param  string  $content  The content.
      */
     public static function getUnescapedContent(string $content): string
     {

--- a/src/Compiler/CompilerServices/LoopVariablesExtractor.php
+++ b/src/Compiler/CompilerServices/LoopVariablesExtractor.php
@@ -17,7 +17,7 @@ class LoopVariablesExtractor
     /**
      * Extracts information about the loop variables in the provided value.
      *
-     * @param  string  $value The content
+     * @param  string  $value  The content
      */
     public function extractDetails(string $value): LoopVariables
     {

--- a/src/Compiler/CompilerServices/StringSplitter.php
+++ b/src/Compiler/CompilerServices/StringSplitter.php
@@ -32,7 +32,7 @@ class StringSplitter extends AbstractParser
     /**
      * Splits a string on whitespace into an array, ignoring line breaks and embedded strings.
      *
-     * @param  string  $input The string to split.
+     * @param  string  $input  The string to split.
      * @return string[]
      */
     public function split(string $input): array

--- a/src/Compiler/CompilerServices/StringUtilities.php
+++ b/src/Compiler/CompilerServices/StringUtilities.php
@@ -10,7 +10,7 @@ class StringUtilities
     /**
      * Lowercases the first character of the input string.
      *
-     * @param  string  $value The value.
+     * @param  string  $value  The value.
      */
     public static function lcfirst(string $value): string
     {
@@ -20,8 +20,8 @@ class StringUtilities
     /**
      * Safely wraps the provided value in the provided quote style, if it is not already.
      *
-     * @param  string  $value The value to wrap.
-     * @param  string  $quoteStyle The quote style. Supply either ' or "
+     * @param  string  $value  The value to wrap.
+     * @param  string  $quoteStyle  The quote style. Supply either ' or "
      */
     public static function wrapInQuotes(string $value, string $quoteStyle): string
     {
@@ -40,7 +40,7 @@ class StringUtilities
     /**
      * Escapes single quotes within the provided string.
      *
-     * @param  string  $value The value to escape.
+     * @param  string  $value  The value to escape.
      */
     public static function escapeSingleQuotes(string $value): string
     {
@@ -50,7 +50,7 @@ class StringUtilities
     /**
      * Normalizes line endings within the provided content.
      *
-     * @param  string  $content The content to normalize.
+     * @param  string  $content  The content to normalize.
      */
     public static function normalizeLineEndings(string $content): string
     {
@@ -60,7 +60,7 @@ class StringUtilities
     /**
      * Wraps the provided value in single quotes if it is not already.
      *
-     * @param  string  $value The string to wrap.
+     * @param  string  $value  The string to wrap.
      */
     public static function wrapInSingleQuotes(string $value): string
     {
@@ -78,7 +78,7 @@ class StringUtilities
     /**
      * Removes balanced parentheses from the provided string.
      *
-     * @param  string  $value The value to unwrap.
+     * @param  string  $value  The value to unwrap.
      */
     public static function unwrapParentheses(string $value): string
     {
@@ -105,7 +105,7 @@ class StringUtilities
     /**
      * Tests if the provided value has leading whitespace.
      *
-     * @param  string  $value The value.
+     * @param  string  $value  The value.
      */
     public static function hasLeadingWhitespace(string $value): bool
     {
@@ -119,7 +119,7 @@ class StringUtilities
     /**
      * Tests if the provided value has trailing whitespace.
      *
-     * @param  string  $value The value.
+     * @param  string  $value  The value.
      */
     public static function hasTrailingWhitespace(string $value): bool
     {
@@ -135,7 +135,7 @@ class StringUtilities
      *
      * A single space will be added to either the start or end.
      *
-     * @param  string  $value The value.
+     * @param  string  $value  The value.
      */
     public static function ensureStringHasWhitespace(string $value): string
     {
@@ -153,7 +153,7 @@ class StringUtilities
     /**
      * Retrieves the leading whitespace from the provided value.
      *
-     * @param  string  $value The value.
+     * @param  string  $value  The value.
      */
     public static function extractLeadingWhitespace(string $value): string
     {
@@ -177,7 +177,7 @@ class StringUtilities
     /**
      * Retrieves the trailing whitespace from the provided value.
      *
-     * @param  string  $value The value.
+     * @param  string  $value  The value.
      */
     public static function extractTrailingWhitespace(string $value): string
     {

--- a/src/Compiler/ComponentNodeCompiler.php
+++ b/src/Compiler/ComponentNodeCompiler.php
@@ -148,7 +148,13 @@ class ComponentNodeCompiler
         $compiler = new Compiler(new DocumentParser());
         $compiler->setCompilationTarget(CompilationTarget::ComponentParameter);
 
-        return $compiler->compileString($node->value);
+        $result = $compiler->compileString($node->value);
+
+        if ($node->type == ParameterType::InterpolatedValue && Str::startsWith($node->value, '{{') && Str::endsWith($node->value, '}}')) {
+            $result = "'".$result."'";
+        }
+
+        return $result;
     }
 
     protected function toAttributeArray(ComponentNode $component): array

--- a/src/Compiler/ComponentTagCompiler.php
+++ b/src/Compiler/ComponentTagCompiler.php
@@ -27,6 +27,13 @@ class ComponentTagCompiler
         $this->parser = $parser;
     }
 
+    public function ignoreDirectives(array $directives): ComponentTagCompiler
+    {
+        $this->parser->ignoreDirectives($directives);
+
+        return $this;
+    }
+
     public function registerCustomCompiler(string $tagName, CustomComponentTagCompiler $compiler): ComponentTagCompiler
     {
         $this->customCompilers[$tagName] = $compiler;

--- a/src/Compiler/Concerns/CompilesEchos.php
+++ b/src/Compiler/Concerns/CompilesEchos.php
@@ -22,7 +22,7 @@ trait CompilesEchos
      * `Illuminate\View\Compilers\BladeCompiler::$echoHandlers`
      * protected property.
      *
-     * @param  array  $handlers The echo handlers.
+     * @param  array  $handlers  The echo handlers.
      */
     public function setEchoHandlers(array $handlers): void
     {

--- a/src/Compiler/Concerns/ManagesCustomConditions.php
+++ b/src/Compiler/Concerns/ManagesCustomConditions.php
@@ -12,8 +12,8 @@ trait ManagesCustomConditions
      * *not* need to manually call this method to sync compiler information
      * if you use the default compiler factory methods/service bindings.
      *
-     * @param  string  $name The condition handler name.
-     * @param  callable  $callback The condition handler.
+     * @param  string  $name  The condition handler name.
+     * @param  callable  $callback  The condition handler.
      */
     public function if(string $name, callable $callback): void
     {

--- a/src/Compiler/Concerns/ManagesCustomDirectives.php
+++ b/src/Compiler/Concerns/ManagesCustomDirectives.php
@@ -9,6 +9,16 @@ use Stillat\BladeParser\Compiler\CompilerServices\DirectiveNameValidator;
 trait ManagesCustomDirectives
 {
     /**
+     * Sets the compiler's custom directives compilers.
+     *
+     * @param  array  $directives The directive compilers.
+     */
+    public function setCustomDirectives(array $directives): void
+    {
+        $this->customDirectives = $directives;
+    }
+
+    /**
      * Get the list of custom directives.
      */
     public function getCustomDirectives(): array

--- a/src/Compiler/Concerns/ManagesCustomDirectives.php
+++ b/src/Compiler/Concerns/ManagesCustomDirectives.php
@@ -11,7 +11,7 @@ trait ManagesCustomDirectives
     /**
      * Sets the compiler's custom directives compilers.
      *
-     * @param  array  $directives The directive compilers.
+     * @param  array  $directives  The directive compilers.
      */
     public function setCustomDirectives(array $directives): void
     {
@@ -34,7 +34,7 @@ trait ManagesCustomDirectives
      * *not* need to manually call this method to sync compiler information
      * if you use the default compiler factory methods/service bindings.
      */
-    public function aliasComponent(string $path, string $alias = null): void
+    public function aliasComponent(string $path, ?string $alias = null): void
     {
         $alias = $alias ?: Arr::last(explode('.', $path));
 
@@ -57,7 +57,7 @@ trait ManagesCustomDirectives
      * *not* need to manually call this method to sync compiler information
      * if you use the default compiler factory methods/service bindings.
      */
-    public function include(string $path, string $alias = null): void
+    public function include(string $path, ?string $alias = null): void
     {
         $this->aliasInclude($path, $alias);
     }
@@ -70,7 +70,7 @@ trait ManagesCustomDirectives
      * *not* need to manually call this method to sync compiler information
      * if you use the default compiler factory methods/service bindings.
      */
-    public function aliasInclude(string $path, string $alias = null): void
+    public function aliasInclude(string $path, ?string $alias = null): void
     {
         $alias = $alias ?: Arr::last(explode('.', $path));
 
@@ -89,8 +89,8 @@ trait ManagesCustomDirectives
      * *not* need to manually call this method to sync compiler information
      * if you use the default compiler factory methods/service bindings.
      *
-     * @param  string  $name The directive name.
-     * @param  callable  $handler The handler
+     * @param  string  $name  The directive name.
+     * @param  callable  $handler  The handler
      *
      * @throws InvalidArgumentException
      */

--- a/src/Compiler/Transformers/RawTransformer.php
+++ b/src/Compiler/Transformers/RawTransformer.php
@@ -48,7 +48,7 @@ class RawTransformer
     /**
      * Transforms an array of nodes into a string with raw blocks.
      *
-     * @param  array  $nodes The nodes
+     * @param  array  $nodes  The nodes
      */
     public function transform(array $nodes): string
     {
@@ -76,7 +76,7 @@ class RawTransformer
     /**
      * Replaces raw placeholders within a previously transformed string.
      *
-     * @param  string  $document The previously transformed string.
+     * @param  string  $document  The previously transformed string.
      */
     public function reverseTransformation(string $document): string
     {

--- a/src/Console/Commands/ValidateBladeCommand.php
+++ b/src/Console/Commands/ValidateBladeCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Stillat\BladeParser\Document\Document;
 use Stillat\BladeParser\Errors\BladeError;
 use Stillat\BladeParser\Errors\ErrorFamily;
+use Stillat\BladeParser\Providers\ValidatorServiceProvider;
 use Stillat\BladeParser\Validation\Workspaces\PhpStanWrapper;
 use Stillat\BladeParser\Workspaces\Workspace;
 
@@ -31,7 +32,7 @@ class ValidateBladeCommand extends Command
         $totalStart = microtime(true);
         $bladeStart = microtime(true);
         $workspace->withCoreValidators()
-            ->ignoreDirectives(config('blade.validation.ignore_directives', []))
+            ->ignoreDirectives(ValidatorServiceProvider::getIgnoreDirectives())
             ->addDirectory(resource_path('views'));
 
         $runMessage = "Running {$workspace->validator()->getValidatorCount()} validators against {$workspace->getFileCount()} files.";

--- a/src/Console/Commands/ValidateBladeCommand.php
+++ b/src/Console/Commands/ValidateBladeCommand.php
@@ -31,6 +31,7 @@ class ValidateBladeCommand extends Command
         $totalStart = microtime(true);
         $bladeStart = microtime(true);
         $workspace->withCoreValidators()
+            ->ignoreDirectives(config('blade.validation.ignore_directives', []))
             ->addDirectory(resource_path('views'));
 
         $runMessage = "Running {$workspace->validator()->getValidatorCount()} validators against {$workspace->getFileCount()} files.";

--- a/src/Document/Concerns/ManagesDocumentValidation.php
+++ b/src/Document/Concerns/ManagesDocumentValidation.php
@@ -32,7 +32,7 @@ trait ManagesDocumentValidation
     /**
      * Adds a single node validator instance to the internal `BladeValidator` instance.
      *
-     * @param  AbstractNodeValidator  $validator The node validator.
+     * @param  AbstractNodeValidator  $validator  The node validator.
      */
     public function addValidator(AbstractNodeValidator $validator): Document
     {
@@ -44,7 +44,7 @@ trait ManagesDocumentValidation
     /**
      * Adds a single document validator instance to the internal `BladeValidator` instance.
      *
-     * @param  AbstractDocumentValidator  $validator The document validator.
+     * @param  AbstractDocumentValidator  $validator  The document validator.
      */
     public function addDocumentValidator(AbstractDocumentValidator $validator): Document
     {
@@ -74,7 +74,7 @@ trait ManagesDocumentValidation
     /**
      * Adds a validator instance to the internal `BladeValidator` instance.
      *
-     * @param  AbstractNodeValidator  $validator The validator instance.
+     * @param  AbstractNodeValidator  $validator  The validator instance.
      */
     public function withValidator(AbstractNodeValidator $validator): Document
     {
@@ -84,7 +84,7 @@ trait ManagesDocumentValidation
     /**
      * Adds a list of validator instances to the internal `BladeValidator` instance.
      *
-     * @param  AbstractNodeValidator[]  $validators The validator instances.
+     * @param  AbstractNodeValidator[]  $validators  The validator instances.
      */
     public function withValidators(array $validators): Document
     {
@@ -114,7 +114,7 @@ trait ManagesDocumentValidation
      * as the `getValidationErrors()` method to retrieve only
      * the validation errors.
      *
-     * @param  BladeValidator  $validator The validator instance.
+     * @param  BladeValidator  $validator  The validator instance.
      */
     public function validateWith(BladeValidator $validator): Document
     {

--- a/src/Document/Concerns/ManagesTextExtraction.php
+++ b/src/Document/Concerns/ManagesTextExtraction.php
@@ -12,8 +12,8 @@ trait ManagesTextExtraction
     /**
      * Returns the original document text between two character offsets.
      *
-     * @param  int  $startOffset The start offset.
-     * @param  int  $endOffset The end offset.
+     * @param  int  $startOffset  The start offset.
+     * @param  int  $endOffset  The end offset.
      */
     public function getText(int $startOffset, int $endOffset): string
     {
@@ -35,7 +35,7 @@ trait ManagesTextExtraction
     /**
      * Retrieves the inner document text between a node pair.
      *
-     * @param  DirectiveNode|ComponentNode  $node The node.
+     * @param  DirectiveNode|ComponentNode  $node  The node.
      */
     public function getPairedNodeInnerDocumentText(DirectiveNode|ComponentNode $node): string
     {
@@ -49,7 +49,7 @@ trait ManagesTextExtraction
     /**
      * Retrieves the outer document text for a given node pair.
      *
-     * @param  DirectiveNode|ComponentNode  $node The node.
+     * @param  DirectiveNode|ComponentNode  $node  The node.
      */
     public function getPairedNodeOuterDocumentText(DirectiveNode|ComponentNode $node): string
     {
@@ -77,7 +77,7 @@ trait ManagesTextExtraction
     /**
      * Retrieves the line number for the provided character offset.
      *
-     * @param  int  $offset The character offset.
+     * @param  int  $offset  The character offset.
      */
     public function getLineNumberFromOffset(int $offset): int
     {
@@ -87,7 +87,7 @@ trait ManagesTextExtraction
     /**
      * Returns the column number for the provided character offset.
      *
-     * @param  int  $offset The character offset.
+     * @param  int  $offset  The character offset.
      */
     public function getColumnNumberFromOffset(int $offset): int
     {
@@ -117,8 +117,8 @@ trait ManagesTextExtraction
     /**
      * Retrieves a word from the source document at the provided character offset.
      *
-     * @param  int  $offset The character offset.
-     * @param  array  $chars A list of characters that won't break a word.
+     * @param  int  $offset  The character offset.
+     * @param  array  $chars  A list of characters that won't break a word.
      */
     public function getWordAtOffset(int $offset, array $chars = ['-']): ?string
     {
@@ -179,8 +179,8 @@ trait ManagesTextExtraction
     /**
      * Returns the closest word character offset to the left of the provided character offset.
      *
-     * @param  int  $offset The character offset.
-     * @param  array  $chars A list of characters that won't break a word.
+     * @param  int  $offset  The character offset.
+     * @param  array  $chars  A list of characters that won't break a word.
      */
     public function getNextWordPositionLeftAtOffset(int $offset, array $chars = ['-']): ?int
     {
@@ -218,8 +218,8 @@ trait ManagesTextExtraction
     /**
      * Retrieves the nearest word character offset to the right of the provided character offset.
      *
-     * @param  int  $offset The character offset.
-     * @param  array  $chars A list of characters that won't break a word.
+     * @param  int  $offset  The character offset.
+     * @param  array  $chars  A list of characters that won't break a word.
      */
     public function getNextWordPositionRightAtOffset(int $offset, array $chars = ['-']): ?int
     {
@@ -257,8 +257,8 @@ trait ManagesTextExtraction
     /**
      * Retrieves the word to the left of the provided offset, ignoring the word at the provided offset.
      *
-     * @param  int  $offset The character offset.
-     * @param  array  $chars A list of characters that won't break a word.
+     * @param  int  $offset  The character offset.
+     * @param  array  $chars  A list of characters that won't break a word.
      */
     public function getWordLeftAtOffset(int $offset, array $chars = ['-']): ?string
     {
@@ -274,8 +274,8 @@ trait ManagesTextExtraction
     /**
      * Retrieves the word to the right of the provided offset, ignoring the word at the provided offset.
      *
-     * @param  int  $offset The character offset.
-     * @param  array  $chars A list of characters that won't break a word.
+     * @param  int  $offset  The character offset.
+     * @param  array  $chars  A list of characters that won't break a word.
      */
     public function getWordRightAtOffset(int $offset, array $chars = ['-']): ?string
     {
@@ -294,8 +294,8 @@ trait ManagesTextExtraction
      * The keys of the returned array will correspond
      * to the line number the text was extracted from.
      *
-     * @param  int  $lineNumber The target line number.
-     * @param  int  $radius The number of desired lines surrounding the target line number.
+     * @param  int  $lineNumber  The target line number.
+     * @param  int  $radius  The number of desired lines surrounding the target line number.
      * @return string[]
      */
     public function getLineExcerpt(int $lineNumber, int $radius = 2): array

--- a/src/Document/Document.php
+++ b/src/Document/Document.php
@@ -79,7 +79,7 @@ class Document
      * but can be used by other features such as Workspaces
      * or some validators.
      *
-     * @param  string|null  $path The file path.
+     * @param  string|null  $path  The file path.
      */
     public function setFilePath(?string $path): Document
     {
@@ -105,7 +105,7 @@ class Document
      * If you are using the `Blade::fromText($template)` static API,
      * this is managed for you.
      *
-     * @param  array  $directives The directive names.
+     * @param  array  $directives  The directive names.
      * @return $this
      */
     public function setDirectiveNames(array $directives): Document
@@ -150,8 +150,8 @@ class Document
      * as the original document text. The original document text
      * will be used with other features, like text extraction.
      *
-     * @param  AbstractNode[]  $nodes The nodes.
-     * @param  string  $nodeText The original document text.
+     * @param  AbstractNode[]  $nodes  The nodes.
+     * @param  string  $nodeText  The original document text.
      */
     public function setNodes(array $nodes, string $nodeText): Document
     {
@@ -178,7 +178,7 @@ class Document
      * Calling this method will *overwrite* any existing `BladeError`
      * instances on the current instance.
      *
-     * @param  BladeError[]  $errors The errors.
+     * @param  BladeError[]  $errors  The errors.
      */
     public function setErrors(array $errors): Document
     {
@@ -209,7 +209,7 @@ class Document
      * already have a `BladeError` instance, you should call the
      * `addValidationError(BladeError $error)` method instead.
      *
-     * @param  ValidationResult  $result The validation result.
+     * @param  ValidationResult  $result  The validation result.
      * @return $this
      */
     public function addValidationResult(ValidationResult $result): Document
@@ -224,7 +224,7 @@ class Document
      * of validation errors. Validation errors are stored separately
      * from other errors, and can be retrieved independently.
      *
-     * @param  BladeError  $error The Blade error.
+     * @param  BladeError  $error  The Blade error.
      * @return $this
      */
     public function addValidationError(BladeError $error): Document
@@ -291,7 +291,7 @@ class Document
      *
      * @internal
      *
-     * @param  DocumentParser  $parser The parser instance.
+     * @param  DocumentParser  $parser  The parser instance.
      * @return $this
      */
     public function syncFromParser(DocumentParser $parser): Document
@@ -307,16 +307,20 @@ class Document
      * The Document instance returned from this method is created by
      * invoking `DocumentFactory::makeDocument()`.
      *
-     * @param  string  $document The template content.
-     * @param  string|null  $filePath An optional file path.
-     * @param  string[]  $customComponentTags A list of custom component tag names.
-     * @param  DocumentOptions|null  $documentOptions Custom document options, if any.
+     * @param  string  $document  The template content.
+     * @param  string|null  $filePath  An optional file path.
+     * @param  string[]  $customComponentTags  A list of custom component tag names.
+     * @param  DocumentOptions|null  $documentOptions  Custom document options, if any.
      */
-    public static function fromText(string $document, string $filePath = null, array $customComponentTags = [], DocumentOptions $documentOptions = null): Document
+    public static function fromText(string $document, ?string $filePath = null, array $customComponentTags = [], ?DocumentOptions $documentOptions = null): Document
     {
         $parser = DocumentParserFactory::makeDocumentParser();
 
         if ($documentOptions) {
+            if ($documentOptions->ignoreDirectives) {
+                $parser->ignoreDirectives($documentOptions->ignoreDirectives);
+            }
+
             if (! $documentOptions->withCoreDirectives) {
                 $parser->withoutCoreDirectives();
             }
@@ -340,7 +344,7 @@ class Document
      * sequences in the produced text. This behavior can be
      * changed by supplying a "falsey" value for the `$unEscaped` parameter.
      *
-     * @param  bool  $unEscaped Whether to return unescaped text.
+     * @param  bool  $unEscaped  Whether to return unescaped text.
      */
     public function extractText(bool $unEscaped = true): string
     {
@@ -384,11 +388,12 @@ class Document
      * @throws CompilationException
      * @throws UnsupportedNodeException
      */
-    public function compile(DocumentCompilerOptions $options = null): string
+    public function compile(?DocumentCompilerOptions $options = null): string
     {
         $compiler = CompilerFactory::makeCompiler();
 
         if ($options != null) {
+            $compiler->ignoreDirectives($options->ignoreDirectives);
             $compiler->setFailOnParserErrors($options->failOnParserErrors);
             $compiler->setParserErrorsIsStrict($options->failStrictly);
             $compiler->setThrowExceptionOnUnknownComponentClass($options->throwExceptionOnUnknownComponentClass);
@@ -426,7 +431,7 @@ class Document
      * already been performed on the document, calling this
      * method may remove the start or ending node of existing pairs.
      *
-     * @param  AbstractNode  $node The node to remove.
+     * @param  AbstractNode  $node  The node to remove.
      * @return $this
      */
     public function removeNode(AbstractNode $node): Document

--- a/src/Document/DocumentCompilerOptions.php
+++ b/src/Document/DocumentCompilerOptions.php
@@ -5,12 +5,12 @@ namespace Stillat\BladeParser\Document;
 class DocumentCompilerOptions
 {
     /**
-     * @param  bool  $failOnParserErrors Indicates if the compiler should fail on parser errors.
-     * @param  bool  $failStrictly Indicates if the compiler should fail on any error.
-     * @param  bool  $throwExceptionOnUnknownComponentClass Indicates if the compiler should throw exceptions when encountering unknown component classes.
-     * @param  callable[]  $appendCallbacks A list of append callbacks that the compiler will invoke.
-     * @param  array  $customTagCompilers A mapping of custom tag compilers.
-     * @param  bool  $compileCoreComponentTags Whether to compile core component tags.
+     * @param  bool  $failOnParserErrors  Indicates if the compiler should fail on parser errors.
+     * @param  bool  $failStrictly  Indicates if the compiler should fail on any error.
+     * @param  bool  $throwExceptionOnUnknownComponentClass  Indicates if the compiler should throw exceptions when encountering unknown component classes.
+     * @param  callable[]  $appendCallbacks  A list of append callbacks that the compiler will invoke.
+     * @param  array  $customTagCompilers  A mapping of custom tag compilers.
+     * @param  bool  $compileCoreComponentTags  Whether to compile core component tags.
      */
     public function __construct(
         public bool $failOnParserErrors = false,
@@ -18,7 +18,8 @@ class DocumentCompilerOptions
         public bool $throwExceptionOnUnknownComponentClass = true,
         public array $appendCallbacks = [],
         public array $customTagCompilers = [],
-        public bool $compileCoreComponentTags = true)
+        public bool $compileCoreComponentTags = true,
+        public array $ignoreDirectives = [])
     {
     }
 }

--- a/src/Document/DocumentOptions.php
+++ b/src/Document/DocumentOptions.php
@@ -15,6 +15,12 @@ class DocumentOptions
          * @var string[] $customDirectives
          */
         public array $customDirectives = [],
+        /**
+         * A list of directives that should be ignored.
+         *
+         * @var string[] $ignoreDirectives
+         */
+        public array $ignoreDirectives = [],
     ) {
     }
 }

--- a/src/Document/NodeUtilities/QueriesComponents.php
+++ b/src/Document/NodeUtilities/QueriesComponents.php
@@ -35,7 +35,7 @@ trait QueriesComponents
     /**
      * Returns the first component tag within the document with the provided name.
      *
-     * @param  string  $tagName The tag name to filter on.
+     * @param  string  $tagName  The tag name to filter on.
      */
     public function findComponentByTagName(string $tagName): ?ComponentNode
     {
@@ -48,7 +48,7 @@ trait QueriesComponents
      * This method will return *all* component tags that match the
      * provided name, including closing tags.
      *
-     * @param  string  $tagName The tag name to filter on.
+     * @param  string  $tagName  The tag name to filter on.
      */
     public function findComponentsByTagName(string $tagName): NodeCollection
     {

--- a/src/Document/NodeUtilities/QueriesGeneralNodes.php
+++ b/src/Document/NodeUtilities/QueriesGeneralNodes.php
@@ -173,7 +173,7 @@ trait QueriesGeneralNodes
      * Returns the first instance of `DirectiveNode` with the provided name. Returns `null`
      * if no directive was found.
      *
-     * @param  string  $name The directive name.
+     * @param  string  $name  The directive name.
      */
     public function findDirectiveByName(string $name): ?DirectiveNode
     {
@@ -185,7 +185,7 @@ trait QueriesGeneralNodes
     /**
      * Returns all directives with the provided name in the source document.
      *
-     * @param  string  $name The directive name to search
+     * @param  string  $name  The directive name to search
      */
     public function findDirectivesByName(string $name): NodeCollection
     {
@@ -197,7 +197,7 @@ trait QueriesGeneralNodes
     /**
      * Tests if the document contains a directive with the provided name.
      *
-     * @param  string  $name The directive name.
+     * @param  string  $name  The directive name.
      */
     public function hasDirective(string $name): bool
     {

--- a/src/Document/NodeUtilities/QueriesGenerics.php
+++ b/src/Document/NodeUtilities/QueriesGenerics.php
@@ -17,7 +17,7 @@ trait QueriesGenerics
     /**
      * Finds all nodes of the provided type.
      *
-     * @param  string  $type The type to search.
+     * @param  string  $type  The type to search.
      */
     public function allOfType(string $type): NodeCollection
     {
@@ -35,7 +35,7 @@ trait QueriesGenerics
     /**
      * Finds all nodes that are not of the provided type.
      *
-     * @param  string  $type The type to search.
+     * @param  string  $type  The type to search.
      */
     public function allNotOfType(string $type): NodeCollection
     {
@@ -53,7 +53,7 @@ trait QueriesGenerics
     /**
      * Locates the first instance of the provided node type in the document.
      *
-     * @param  string  $type The node type.
+     * @param  string  $type  The node type.
      */
     public function firstOfType(string $type): ?AbstractNode
     {
@@ -69,7 +69,7 @@ trait QueriesGenerics
     /**
      * Tests if the document contains any node of the provided type.
      *
-     * @param  string  $type The desired type.
+     * @param  string  $type  The desired type.
      */
     public function hasAnyOfType(string $type): bool
     {
@@ -85,7 +85,7 @@ trait QueriesGenerics
     /**
      * Locates the last instance of the provided node type in the document.
      *
-     * @param  string  $type The node type.
+     * @param  string  $type  The node type.
      */
     public function lastOfType(string $type): ?AbstractNode
     {
@@ -97,7 +97,7 @@ trait QueriesGenerics
      *
      * Pattern searches exclude instances of `LiteralNode`.
      *
-     * @param  string[]  $pattern The desired pattern.
+     * @param  string[]  $pattern  The desired pattern.
      */
     public function findNodePattern(array $pattern): Collection
     {
@@ -138,8 +138,8 @@ trait QueriesGenerics
      *
      * @internal
      *
-     * @param  int  $index The start index.
-     * @param  int  $withoutLiteralCount The number of nodes to retrieve, not counting literals.
+     * @param  int  $index  The start index.
+     * @param  int  $withoutLiteralCount  The number of nodes to retrieve, not counting literals.
      */
     public function findNodesAt(int $index, int $withoutLiteralCount): NodeCollection
     {
@@ -193,7 +193,7 @@ trait QueriesGenerics
      *
      * @internal
      *
-     * @param  AbstractNode[]  $nodes The nodes.
+     * @param  AbstractNode[]  $nodes  The nodes.
      */
     public function getNodeSearchSpace(array $nodes): array
     {

--- a/src/Document/NodeUtilities/QueriesRelativeNodes.php
+++ b/src/Document/NodeUtilities/QueriesRelativeNodes.php
@@ -14,7 +14,7 @@ trait QueriesRelativeNodes
      *
      * Only the node's starting position is considered.
      *
-     * @param  int  $line The target line.
+     * @param  int  $line  The target line.
      */
     public function findAllNodesStartingOnLine(int $line): NodeCollection
     {
@@ -34,7 +34,7 @@ trait QueriesRelativeNodes
      *
      * @internal
      *
-     * @param  array|string  $directiveNames The directive names to break on.
+     * @param  array|string  $directiveNames  The directive names to break on.
      */
     public function partitionOnDirectives(array|string $directiveNames): PartitionResult
     {
@@ -81,7 +81,7 @@ trait QueriesRelativeNodes
      *
      * @internal
      *
-     * @param  AbstractNode  $node The node to split on.
+     * @param  AbstractNode  $node  The node to split on.
      */
     public function splitNodesOn(AbstractNode $node): array
     {
@@ -113,7 +113,7 @@ trait QueriesRelativeNodes
     /**
      * Gets all the nodes before the provided node.
      *
-     * @param  AbstractNode  $node The check node.
+     * @param  AbstractNode  $node  The check node.
      */
     public function getNodesBefore(AbstractNode $node): NodeCollection
     {
@@ -132,7 +132,7 @@ trait QueriesRelativeNodes
     /**
      * Gets all the nodes after the provided node.
      *
-     * @param  AbstractNode  $node The check node.
+     * @param  AbstractNode  $node  The check node.
      */
     public function getNodesAfter(AbstractNode $node): NodeCollection
     {
@@ -157,8 +157,8 @@ trait QueriesRelativeNodes
     /**
      * Retrieves all nodes between the provided nodes, including the provided nodes.
      *
-     * @param  AbstractNode  $a The start node.
-     * @param  AbstractNode  $b The end node.
+     * @param  AbstractNode  $a  The start node.
+     * @param  AbstractNode  $b  The end node.
      */
     public function getNodesBetweenInclusive(AbstractNode $a, AbstractNode $b): NodeCollection
     {
@@ -176,7 +176,7 @@ trait QueriesRelativeNodes
     /**
      * Retrieves all parent nodes for the provided node.
      *
-     * @param  AbstractNode  $node The node.
+     * @param  AbstractNode  $node  The node.
      */
     public function getAllParentNodesForNode(AbstractNode $node): NodeCollection
     {
@@ -196,8 +196,8 @@ trait QueriesRelativeNodes
     /**
      * Tests if the provided node has a parent of the requested type.
      *
-     * @param  AbstractNode  $node The node.
-     * @param  string  $type The type.
+     * @param  AbstractNode  $node  The node.
+     * @param  string  $type  The type.
      */
     public function getNodeHasParentOfType(AbstractNode $node, string $type): bool
     {
@@ -207,7 +207,7 @@ trait QueriesRelativeNodes
     /**
      * Tests if the provided node has a condition-like parent.
      *
-     * @param  AbstractNode  $node The node.
+     * @param  AbstractNode  $node  The node.
      */
     public function getNodeHasConditionParent(AbstractNode $node): bool
     {
@@ -217,7 +217,7 @@ trait QueriesRelativeNodes
     /**
      * Tests if the provided node has a `@forelse` directive parent.
      *
-     * @param  AbstractNode  $node The node.
+     * @param  AbstractNode  $node  The node.
      */
     public function getNodeHasForElseParent(AbstractNode $node): bool
     {
@@ -227,7 +227,7 @@ trait QueriesRelativeNodes
     /**
      * Tests if the provided node has a `@switch` directive parent.
      *
-     * @param  AbstractNode  $node The node.
+     * @param  AbstractNode  $node  The node.
      */
     public function getNodeHasSwitchParent(AbstractNode $node): bool
     {

--- a/src/Document/Structures/Concerns/ConstructsSwitchStatements.php
+++ b/src/Document/Structures/Concerns/ConstructsSwitchStatements.php
@@ -38,8 +38,8 @@ trait ConstructsSwitchStatements
     /**
      * Constructs a case statement from the provided nodes.
      *
-     * @param  NodeCollection  $nodes The case nodes.
-     * @param  SwitchStatement  $switch The parent switch statement.
+     * @param  NodeCollection  $nodes  The case nodes.
+     * @param  SwitchStatement  $switch  The parent switch statement.
      */
     private function createCaseStatement(NodeCollection $nodes, SwitchStatement $switch): CaseStatement
     {

--- a/src/Document/Structures/Concerns/ManagesConditionMetaData.php
+++ b/src/Document/Structures/Concerns/ManagesConditionMetaData.php
@@ -29,7 +29,7 @@ trait ManagesConditionMetaData
     /**
      * Tests if the provided node is a condition-like node.
      *
-     * @param  DirectiveNode  $node The node.
+     * @param  DirectiveNode  $node  The node.
      */
     public function isConditionalStructure(DirectiveNode $node): bool
     {
@@ -62,7 +62,7 @@ trait ManagesConditionMetaData
     /**
      * Tests if the provided condition-like node requires a closing directive.
      *
-     * @param  DirectiveNode  $node The node.
+     * @param  DirectiveNode  $node  The node.
      */
     public function conditionRequiresClose(DirectiveNode $node): bool
     {

--- a/src/Document/Structures/DirectiveClosingAnalyzer.php
+++ b/src/Document/Structures/DirectiveClosingAnalyzer.php
@@ -10,7 +10,7 @@ class DirectiveClosingAnalyzer
     /**
      * Analyzes the provided node to determine if it could be a closing directive.
      *
-     * @param  DirectiveNode  $node The node.
+     * @param  DirectiveNode  $node  The node.
      */
     public static function analyze(DirectiveNode $node): void
     {

--- a/src/Nodes/AbstractNode.php
+++ b/src/Nodes/AbstractNode.php
@@ -242,7 +242,7 @@ abstract class AbstractNode extends BaseNode
     /**
      * Sets the node's internal dirty state.
      *
-     * @param  bool  $isDirty The dirty status.
+     * @param  bool  $isDirty  The dirty status.
      */
     protected function setIsDirty(bool $isDirty = true): void
     {

--- a/src/Nodes/ArgumentGroupNode.php
+++ b/src/Nodes/ArgumentGroupNode.php
@@ -96,7 +96,7 @@ class ArgumentGroupNode extends AbstractNode
         return collect((new ArgStringSplitter())->split($this->innerContent));
     }
 
-    public function clone(DirectiveNode $newOwner = null): ArgumentGroupNode
+    public function clone(?DirectiveNode $newOwner = null): ArgumentGroupNode
     {
         $ownerToSet = $this->owner;
 

--- a/src/Nodes/BaseNode.php
+++ b/src/Nodes/BaseNode.php
@@ -43,7 +43,7 @@ class BaseNode
     /**
      * Clones basic details to the provided target node.
      *
-     * @param  BaseNode  $node The target node to copy to.
+     * @param  BaseNode  $node  The target node to copy to.
      */
     public function copyBasicDetailsTo(BaseNode $node): void
     {

--- a/src/Nodes/CommentNode.php
+++ b/src/Nodes/CommentNode.php
@@ -22,8 +22,8 @@ class CommentNode extends AbstractNode
     /**
      * Updates the comment's inner content.
      *
-     * @param  string  $content The comment's content.
-     * @param  bool  $preserveOriginalWhitespace Whether to preserve the original leading and trailing whitespace.
+     * @param  string  $content  The comment's content.
+     * @param  bool  $preserveOriginalWhitespace  Whether to preserve the original leading and trailing whitespace.
      */
     public function setContent(string $content, bool $preserveOriginalWhitespace = true): void
     {

--- a/src/Nodes/Components/ComponentNode.php
+++ b/src/Nodes/Components/ComponentNode.php
@@ -52,8 +52,8 @@ class ComponentNode extends AbstractNode
     /**
      * Renames the component node.
      *
-     * @param  string  $name The new name.
-     * @param  bool  $propagateChanges Whether to push changes to any related structures.
+     * @param  string  $name  The new name.
+     * @param  bool  $propagateChanges  Whether to push changes to any related structures.
      */
     public function rename(string $name, bool $propagateChanges = true): void
     {

--- a/src/Nodes/Components/Concerns/ManagesComponentParameters.php
+++ b/src/Nodes/Components/Concerns/ManagesComponentParameters.php
@@ -12,7 +12,7 @@ trait ManagesComponentParameters
     /**
      * Adds a parameter from text.
      *
-     * @param  string  $parameterContent The parameter content.
+     * @param  string  $parameterContent  The parameter content.
      */
     public function addParameterFromText(string $parameterContent): void
     {
@@ -28,7 +28,7 @@ trait ManagesComponentParameters
     /**
      * Adds a new parameter to the component.
      *
-     * @param  ParameterNode  $parameter The new parameter.
+     * @param  ParameterNode  $parameter  The new parameter.
      *
      * @throws \Stillat\BladeParser\Errors\Exceptions\DuplicateParameterException
      */
@@ -48,7 +48,7 @@ trait ManagesComponentParameters
     /**
      * Removes a parameter instance from the component.
      *
-     * @param  ParameterNode  $parameter The parameter to remove.
+     * @param  ParameterNode  $parameter  The parameter to remove.
      */
     public function removeParameter(ParameterNode $parameter): void
     {
@@ -67,7 +67,7 @@ trait ManagesComponentParameters
     /**
      * Tests if the component contains the provided parameter instance.
      *
-     * @param  ParameterNode  $parameter The parameter.
+     * @param  ParameterNode  $parameter  The parameter.
      */
     public function hasParameterInstance(ParameterNode $parameter): bool
     {
@@ -79,7 +79,7 @@ trait ManagesComponentParameters
     /**
      * Tests if the component contains a parameter with the provided name.
      *
-     * @param  string  $name The parameter name.
+     * @param  string  $name  The parameter name.
      */
     public function hasParameter(string $name): bool
     {
@@ -89,7 +89,7 @@ trait ManagesComponentParameters
     /**
      * Gets the parameter with the provided name.
      *
-     * @param  string  $name The parameter name.
+     * @param  string  $name  The parameter name.
      */
     public function getParameter(string $name): ?ParameterNode
     {

--- a/src/Nodes/Components/ParameterFactory.php
+++ b/src/Nodes/Components/ParameterFactory.php
@@ -9,7 +9,7 @@ class ParameterFactory
     /**
      * Parses parameters within the provided content.
      *
-     * @param  string  $parameterContent The parameter content.
+     * @param  string  $parameterContent  The parameter content.
      */
     public static function fromText(string $parameterContent): array
     {
@@ -21,7 +21,7 @@ class ParameterFactory
     /**
      * Parses a single parameter from the provided content.
      *
-     * @param  string  $parameterContent The parameter content.
+     * @param  string  $parameterContent  The parameter content.
      */
     public static function parameterFromText(string $parameterContent): ?ParameterNode
     {

--- a/src/Nodes/Components/ParameterNode.php
+++ b/src/Nodes/Components/ParameterNode.php
@@ -25,7 +25,7 @@ class ParameterNode extends AbstractNode
     /**
      * Sets the node's internal dirty state.
      *
-     * @param  bool  $isDirty The dirty status.
+     * @param  bool  $isDirty  The dirty status.
      */
     protected function setIsDirty(bool $isDirty = true): void
     {

--- a/src/Nodes/Concerns/InteractsWithBladeErrors.php
+++ b/src/Nodes/Concerns/InteractsWithBladeErrors.php
@@ -57,9 +57,9 @@ trait InteractsWithBladeErrors
     /**
      * Tests if an error matching the provided properties exists on a specific line.
      *
-     * @param  int  $line The line to check.
-     * @param  ErrorType  $type The error type to check for.
-     * @param  ConstructContext  $context The error context.
+     * @param  int  $line  The line to check.
+     * @param  ErrorType  $type  The error type to check for.
+     * @param  ConstructContext  $context  The error context.
      */
     public function hasErrorOnLine(int $line, ErrorType $type, ConstructContext $context): bool
     {

--- a/src/Nodes/DirectiveNode.php
+++ b/src/Nodes/DirectiveNode.php
@@ -225,7 +225,7 @@ class DirectiveNode extends AbstractNode
      *
      * This method does not verify if the provided name is recognized as a directive.
      *
-     * @param  string  $name The new directive name.
+     * @param  string  $name  The new directive name.
      */
     public function setName(string $name): void
     {

--- a/src/Nodes/EchoNode.php
+++ b/src/Nodes/EchoNode.php
@@ -35,7 +35,7 @@ class EchoNode extends AbstractNode
     /**
      * Sets the node's type.
      *
-     * @param  EchoType  $type The type.
+     * @param  EchoType  $type  The type.
      */
     public function setType(EchoType $type): void
     {
@@ -46,7 +46,7 @@ class EchoNode extends AbstractNode
     /**
      * Sets the inner content of the echo node.
      *
-     * @param  string  $innerContent The new content.
+     * @param  string  $innerContent  The new content.
      */
     public function setInnerContent(string $innerContent): void
     {

--- a/src/Nodes/Fragments/HtmlFragment.php
+++ b/src/Nodes/Fragments/HtmlFragment.php
@@ -42,7 +42,7 @@ class HtmlFragment extends Fragment
     /**
      * Tests if the fragment contains the provided parameter.
      *
-     * @param  string  $name The parameter name.
+     * @param  string  $name  The parameter name.
      */
     public function hasParameter(string $name): bool
     {
@@ -52,7 +52,7 @@ class HtmlFragment extends Fragment
     /**
      * Retrieves the parameter with the given name, if it exists.
      *
-     * @param  string  $name The parameter name.
+     * @param  string  $name  The parameter name.
      */
     public function getParameter(string $name): ?FragmentParameter
     {

--- a/src/Nodes/LiteralNode.php
+++ b/src/Nodes/LiteralNode.php
@@ -28,8 +28,8 @@ class LiteralNode extends AbstractNode
      * the content supplied to this method must include the
      * correct escape sequences in order to function.
      *
-     * @param  string  $content The new content.
-     * @param  bool  $preserveOriginalWhitespace Whether to preserve the original trailing and leading whitespace.
+     * @param  string  $content  The new content.
+     * @param  bool  $preserveOriginalWhitespace  Whether to preserve the original trailing and leading whitespace.
      */
     public function setContent(string $content, bool $preserveOriginalWhitespace = true): void
     {

--- a/src/Nodes/NodeIndexer.php
+++ b/src/Nodes/NodeIndexer.php
@@ -7,7 +7,7 @@ class NodeIndexer
     /**
      * Resets the indexes on the provided nodes.
      *
-     * @param  BaseNode[]  $nodes The nodes to index.
+     * @param  BaseNode[]  $nodes  The nodes to index.
      */
     public static function indexNodes(array $nodes): void
     {

--- a/src/Nodes/PhpBlockNode.php
+++ b/src/Nodes/PhpBlockNode.php
@@ -24,8 +24,8 @@ class PhpBlockNode extends AbstractNode
     /**
      * Updates the block's content.
      *
-     * @param  string  $content The new content.
-     * @param  bool  $preserveOriginalWhitespace Whether to preserve the original leading and trailing whitespace.
+     * @param  string  $content  The new content.
+     * @param  bool  $preserveOriginalWhitespace  Whether to preserve the original leading and trailing whitespace.
      */
     public function setContent(string $content, bool $preserveOriginalWhitespace = true): void
     {

--- a/src/Nodes/PhpTagNode.php
+++ b/src/Nodes/PhpTagNode.php
@@ -37,8 +37,8 @@ class PhpTagNode extends AbstractNode
      *
      * This content should not start with a PHP tag, and it should not end with a closing PHP tag.
      *
-     * @param  string  $content The new content.
-     * @param  bool  $preserveOriginalWhitespace Whether to preserve original leading and trailing whitespace.
+     * @param  string  $content  The new content.
+     * @param  bool  $preserveOriginalWhitespace  Whether to preserve original leading and trailing whitespace.
      */
     public function setContent(string $content, bool $preserveOriginalWhitespace = true): void
     {
@@ -56,8 +56,8 @@ class PhpTagNode extends AbstractNode
     /**
      * Updates the tag's type.
      *
-     * @param  PhpTagType  $type The new type.
-     * @param  bool  $preserveOriginalWhitespace Whether to preserve the tag's original leading and trailing whitespace.
+     * @param  PhpTagType  $type  The new type.
+     * @param  bool  $preserveOriginalWhitespace  Whether to preserve the tag's original leading and trailing whitespace.
      */
     public function setType(PhpTagType $type, bool $preserveOriginalWhitespace = true): void
     {

--- a/src/Nodes/Position.php
+++ b/src/Nodes/Position.php
@@ -49,7 +49,7 @@ class Position
     /**
      * Tests if the position contains the provided offset.
      *
-     * @param  int  $offset The offset to test.
+     * @param  int  $offset  The offset to test.
      */
     public function contains(int $offset): bool
     {

--- a/src/Nodes/VerbatimNode.php
+++ b/src/Nodes/VerbatimNode.php
@@ -24,8 +24,8 @@ class VerbatimNode extends AbstractNode
     /**
      * Updates the block's content.
      *
-     * @param  string  $content The new content.
-     * @param  bool  $preserveOriginalWhitespace Whether to preserve original leading and trailing whitespace.
+     * @param  string  $content  The new content.
+     * @param  bool  $preserveOriginalWhitespace  Whether to preserve original leading and trailing whitespace.
      */
     public function setContent(string $content, bool $preserveOriginalWhitespace = true): void
     {

--- a/src/Parser/DocumentParser.php
+++ b/src/Parser/DocumentParser.php
@@ -80,6 +80,8 @@ class DocumentParser extends AbstractParser
 
     private bool $onlyComponents = false;
 
+    private array $ignoreDirectives = [];
+
     public function __construct()
     {
         $this->componentParser = new ComponentParser();
@@ -89,7 +91,7 @@ class DocumentParser extends AbstractParser
     /**
      * Sets the custom directive names.
      *
-     * @param  array  $names The directive names.
+     * @param  array  $names  The directive names.
      * @return $this
      */
     public function setDirectiveNames(array $names): DocumentParser
@@ -110,7 +112,7 @@ class DocumentParser extends AbstractParser
     /**
      * Registers a single custom component tag name.
      *
-     * @param  string  $tagName The component tag name.
+     * @param  string  $tagName  The component tag name.
      * @return $this
      */
     public function registerCustomComponentTag(string $tagName): DocumentParser
@@ -123,7 +125,7 @@ class DocumentParser extends AbstractParser
     /**
      * Registers multiple custom component tag names.
      *
-     * @param  array  $tagNames The tag names.
+     * @param  array  $tagNames  The tag names.
      * @return $this
      */
     public function registerCustomComponentTags(array $tagNames): DocumentParser
@@ -136,7 +138,7 @@ class DocumentParser extends AbstractParser
     /**
      * Registers a single custom directive name.
      *
-     * @param  string  $name The directive name.
+     * @param  string  $name  The directive name.
      */
     public function registerCustomDirective(string $name): void
     {
@@ -172,15 +174,22 @@ class DocumentParser extends AbstractParser
         return $this;
     }
 
+    public function ignoreDirectives(array $directives): DocumentParser
+    {
+        $this->ignoreDirectives = $directives;
+
+        return $this;
+    }
+
     /**
      * Retrieves a list of directive names supported by the parser instance.
      */
     public function getDirectiveNames(): array
     {
-        return array_merge(
+        return array_diff(array_merge(
             $this->coreDirectives,
             $this->customDirectives
-        );
+        ), $this->ignoreDirectives);
     }
 
     /**
@@ -599,7 +608,7 @@ class DocumentParser extends AbstractParser
     /**
      * Parses the input document and returns an array of nodes.
      *
-     * @param  string  $document The input document.
+     * @param  string  $document  The input document.
      * @return AbstractNode[]
      */
     public function parse(string $document): array

--- a/src/Parser/HtmlFragments/BaseFragmentParser.php
+++ b/src/Parser/HtmlFragments/BaseFragmentParser.php
@@ -53,7 +53,7 @@ abstract class BaseFragmentParser
      * Advances the parser over a string, and adds
      * the string's content to the internal buffer.
      *
-     * @param  int  $start The start position.
+     * @param  int  $start  The start position.
      */
     protected function scanToEndOfString(int $start): int
     {

--- a/src/Parser/HtmlFragments/FragmentsDocumentParser.php
+++ b/src/Parser/HtmlFragments/FragmentsDocumentParser.php
@@ -43,7 +43,7 @@ class FragmentsDocumentParser extends BaseFragmentParser
     /**
      * Sets the internal ranges to ignore while parsing.
      *
-     * @param  array  $ignoreRanges The ranges to ignore.
+     * @param  array  $ignoreRanges  The ranges to ignore.
      */
     public function setIgnoreRanges(array $ignoreRanges): void
     {
@@ -53,7 +53,7 @@ class FragmentsDocumentParser extends BaseFragmentParser
     /**
      * Parses an HTML fragment at the provided index.
      *
-     * @param  int  $index The location to begin parsing.
+     * @param  int  $index  The location to begin parsing.
      */
     private function parseFragment(int $index): void
     {
@@ -230,7 +230,7 @@ class FragmentsDocumentParser extends BaseFragmentParser
     /**
      * Parses the input value and returns a list of fragments.
      *
-     * @param  string  $value The value to parse.
+     * @param  string  $value  The value to parse.
      * @return HtmlFragment[]
      */
     public function parse(string $value): array

--- a/src/Providers/ValidatorServiceProvider.php
+++ b/src/Providers/ValidatorServiceProvider.php
@@ -14,13 +14,18 @@ use Stillat\BladeParser\Validation\Workspaces\PhpStanWrapper;
 
 class ValidatorServiceProvider extends ServiceProvider
 {
+    public static function getIgnoreDirectives()
+    {
+        return array_merge(config('blade.validation.ignore_directives', []), ['livewire']);
+    }
+
     public function register()
     {
         $this->mergeConfigFrom(
             __DIR__.'/../../config/validation.php', 'blade.validation'
         );
 
-        $globalIgnoreDirectives = config('blade.validation.ignore_directives', []);
+        $globalIgnoreDirectives = self::getIgnoreDirectives();
         $globalCustomDirectives = config('blade.validation.custom_directives', []);
 
         $availableConfig = config('blade.validation.options');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,6 +27,7 @@ class ServiceProvider extends BaseServiceProvider
             /** @var BladeCompilerDetailsFetcher $fetcher */
             $fetcher = app(BladeCompilerDetailsFetcher::class);
 
+            $compiler->setCustomDirectives($fetcher->getCustomDirectives());
             $compiler->setAnonymousComponentPaths($fetcher->getAnonymousComponentPaths());
             $compiler->setAnonymousComponentNamespaces($fetcher->getAnonymousComponentNamespaces());
             $compiler->setClassComponentAliases($fetcher->getClassComponentAliases());

--- a/src/Support/BladeCompilerDetailsFetcher.php
+++ b/src/Support/BladeCompilerDetailsFetcher.php
@@ -18,6 +18,11 @@ class BladeCompilerDetailsFetcher
         $this->reflection = new ReflectionClass(BladeCompiler::class);
     }
 
+    public function getCustomDirectives(): array
+    {
+        return $this->compiler->getCustomDirectives();
+    }
+
     /**
      * Retrieves the Blade precompilers.
      *

--- a/src/Validation/AbstractDocumentValidator.php
+++ b/src/Validation/AbstractDocumentValidator.php
@@ -14,7 +14,7 @@ abstract class AbstractDocumentValidator extends AbstractValidator
      * if they wish to report multiple results at once, or may return `null`
      * if there are no results to report for the provided node.
      *
-     * @param  Document  $document The document to analyze.
+     * @param  Document  $document  The document to analyze.
      */
     abstract public function validate(Document $document): ValidationResult|array|null;
 }

--- a/src/Validation/AbstractNodeValidator.php
+++ b/src/Validation/AbstractNodeValidator.php
@@ -14,7 +14,7 @@ abstract class AbstractNodeValidator extends AbstractValidator
      * if they wish to report multiple results at once, or may return `null`
      * if there are no results to report for the provided node.
      *
-     * @param  AbstractNode  $node The node to validate.
+     * @param  AbstractNode  $node  The node to validate.
      */
     abstract public function validate(AbstractNode $node): ValidationResult|array|null;
 }

--- a/src/Validation/AbstractValidator.php
+++ b/src/Validation/AbstractValidator.php
@@ -34,7 +34,7 @@ abstract class AbstractValidator
      * provide the developer the opportunity to configure
      * their validation systems however they like.
      *
-     * @param  array  $config The configuration.
+     * @param  array  $config  The configuration.
      */
     public function loadConfiguration(array $config): void
     {
@@ -54,7 +54,7 @@ abstract class AbstractValidator
     /**
      * Retrieves a directive's argument contents.
      *
-     * @param  DirectiveNode  $node The directive node.
+     * @param  DirectiveNode  $node  The directive node.
      */
     protected function getDirectiveArgContents(DirectiveNode $node): string
     {
@@ -70,8 +70,8 @@ abstract class AbstractValidator
     /**
      * Helper method to construct a new instance of `ValidationResult` with basic details.
      *
-     * @param  AbstractNode  $subject The node.
-     * @param  string  $message The validation result message.
+     * @param  AbstractNode  $subject  The node.
+     * @param  string  $message  The validation result message.
      */
     protected function makeValidationResult(AbstractNode $subject, string $message = ''): ValidationResult
     {

--- a/src/Validation/BladeValidator.php
+++ b/src/Validation/BladeValidator.php
@@ -92,7 +92,7 @@ class BladeValidator
      *
      * @internal
      *
-     * @param  AbstractNodeValidator[]  $instances The node validator instances.
+     * @param  AbstractNodeValidator[]  $instances  The node validator instances.
      * @return $this
      */
     public function setCoreValidatorInstances(array $instances): BladeValidator
@@ -110,7 +110,7 @@ class BladeValidator
      *
      * @internal
      *
-     * @param  AbstractDocumentValidator[]  $instances The document validator instances.
+     * @param  AbstractDocumentValidator[]  $instances  The document validator instances.
      * @return $this
      */
     public function setCoreDocumentValidatorInstances(array $instances): BladeValidator
@@ -174,7 +174,7 @@ class BladeValidator
     /**
      * Tests if the `BladeValidator` instance contains the provided validator.
      *
-     * @param  AbstractNodeValidator  $validator The validator to check.
+     * @param  AbstractNodeValidator  $validator  The validator to check.
      */
     public function hasValidatorInstance(AbstractNodeValidator $validator): bool
     {
@@ -190,7 +190,7 @@ class BladeValidator
     /**
      * Tests if the `BladeValidator` instance contains the provided validator.
      *
-     * @param  AbstractDocumentValidator  $validator The validator to check.
+     * @param  AbstractDocumentValidator  $validator  The validator to check.
      */
     public function hasDocumentValidatorInstance(AbstractDocumentValidator $validator): bool
     {
@@ -207,7 +207,7 @@ class BladeValidator
      * Tests if the `BladeValidator` instance contains any validator
      * instance with the provided class name.
      *
-     * @param  string  $validatorClass The class name to check.
+     * @param  string  $validatorClass  The class name to check.
      */
     public function hasValidatorClass(string $validatorClass): bool
     {
@@ -217,7 +217,7 @@ class BladeValidator
     /**
      * Removes a validator instance with the provided validator class name.
      *
-     * @param  string  $validatorClass The validator class name.
+     * @param  string  $validatorClass  The validator class name.
      * @return $this
      */
     public function removeValidator(string $validatorClass): BladeValidator
@@ -238,7 +238,7 @@ class BladeValidator
     /**
      * Registers a document validator with the `BladeValidator` instance.
      *
-     * @param  AbstractDocumentValidator  $validator The validator instance.
+     * @param  AbstractDocumentValidator  $validator  The validator instance.
      * @return $this
      */
     public function addDocumentValidator(AbstractDocumentValidator $validator): BladeValidator
@@ -262,7 +262,7 @@ class BladeValidator
     /**
      * Registers multiple document validators with the `BladeValidator` instance.
      *
-     * @param  AbstractDocumentValidator[]  $validators The document validator instances.
+     * @param  AbstractDocumentValidator[]  $validators  The document validator instances.
      * @return $this
      */
     public function addDocumentValidators(array $validators): BladeValidator
@@ -277,7 +277,7 @@ class BladeValidator
     /**
      * Registers a single node validator instance with the `BladeValidator` instance.
      *
-     * @param  AbstractNodeValidator  $validator The node validator instance.
+     * @param  AbstractNodeValidator  $validator  The node validator instance.
      * @return $this
      */
     public function addValidator(AbstractNodeValidator $validator): BladeValidator
@@ -301,7 +301,7 @@ class BladeValidator
     /**
      * Adds the validators to validator instance.
      *
-     * @param  AbstractNodeValidator[]  $validators The validators.
+     * @param  AbstractNodeValidator[]  $validators  The validators.
      */
     public function addValidators(array $validators): BladeValidator
     {
@@ -333,7 +333,7 @@ class BladeValidator
     /**
      * Runs all registered node validators against the provided node list.
      *
-     * @param  AbstractNode[]  $nodes The nodes to validate.
+     * @param  AbstractNode[]  $nodes  The nodes to validate.
      */
     public function validateNodes(array $nodes): Collection
     {
@@ -368,7 +368,7 @@ class BladeValidator
      * This method will *not* automatically run registered node validators
      * against the document's nodes.
      *
-     * @param  Document  $document The document to validate.
+     * @param  Document  $document  The document to validate.
      */
     public function validateDocument(Document $document): Collection
     {

--- a/src/Validation/PhpSyntaxValidator.php
+++ b/src/Validation/PhpSyntaxValidator.php
@@ -8,6 +8,7 @@ use ParseError;
 use Stillat\BladeParser\Compiler\AppendState;
 use Stillat\BladeParser\Document\Document;
 use Stillat\BladeParser\Document\DocumentCompilerOptions;
+use Stillat\BladeParser\Document\DocumentOptions;
 use Stillat\BladeParser\Nodes\AbstractNode;
 use Stillat\BladeParser\Nodes\DirectiveNode;
 use Stillat\BladeParser\Nodes\LiteralNode;
@@ -28,6 +29,7 @@ class PhpSyntaxValidator
     {
         $this->compilerOptions = new DocumentCompilerOptions();
         $this->compilerOptions->throwExceptionOnUnknownComponentClass = false;
+        $this->compilerOptions->ignoreDirectives = config('blade.validation.ignore_directives', []);
         $this->compilerOptions->appendCallbacks[] = function (AppendState $state) {
             for ($i = $state->beforeLineNumber; $i <= $state->afterLineNumber; $i++) {
                 $this->sourceMap[$i] = $state->node->position->startLine;
@@ -46,16 +48,17 @@ class PhpSyntaxValidator
     /**
      * Checks the provided document for any potential PHP syntax errors.
      *
-     * @param  Document  $document The document instance.
-     * @param  int|null  $originalLine An optional line number that will be used instead of any reported PHP line numbers.
+     * @param  Document  $document  The document instance.
+     * @param  int|null  $originalLine  An optional line number that will be used instead of any reported PHP line numbers.
      */
-    public function checkDocument(Document $document, int $originalLine = null): PhpSyntaxValidationResult
+    public function checkDocument(Document $document, ?int $originalLine = null): PhpSyntaxValidationResult
     {
         $this->resetState();
         $syntaxResult = new PhpSyntaxValidationResult();
 
         try {
             $compiled = $document->compile($this->compilerOptions);
+
             $error = $this->checkForErrors($compiled);
 
             if ($error == null || Str::contains($error->getMessage(), 'end of input')) {
@@ -104,18 +107,20 @@ class PhpSyntaxValidator
     /**
      * Checks the provided content for any potential PHP syntax errors.
      *
-     * @param  string  $content The value to check.
-     * @param  int|null  $originalLine An optional line number that will be used instead of any reported PHP line number.
+     * @param  string  $content  The value to check.
+     * @param  int|null  $originalLine  An optional line number that will be used instead of any reported PHP line number.
      */
-    public function checkString(string $content, int $originalLine = null): PhpSyntaxValidationResult
+    public function checkString(string $content, ?int $originalLine = null): PhpSyntaxValidationResult
     {
-        return $this->checkDocument(Document::fromText($content), $originalLine);
+        return $this->checkDocument(
+            Document::fromText($content, documentOptions: new DocumentOptions(ignoreDirectives: config('blade.validation.ignore_directives', []))), $originalLine
+        );
     }
 
     /**
      * Attempts to locate any PHP syntax errors within the provided content.
      *
-     * @param  string  $content The PHP content.
+     * @param  string  $content  The PHP content.
      */
     private function checkForErrors(string $content): ?ParseError
     {

--- a/src/Validation/PhpSyntaxValidator.php
+++ b/src/Validation/PhpSyntaxValidator.php
@@ -12,6 +12,7 @@ use Stillat\BladeParser\Document\DocumentOptions;
 use Stillat\BladeParser\Nodes\AbstractNode;
 use Stillat\BladeParser\Nodes\DirectiveNode;
 use Stillat\BladeParser\Nodes\LiteralNode;
+use Stillat\BladeParser\Providers\ValidatorServiceProvider;
 
 class PhpSyntaxValidator
 {
@@ -29,7 +30,7 @@ class PhpSyntaxValidator
     {
         $this->compilerOptions = new DocumentCompilerOptions();
         $this->compilerOptions->throwExceptionOnUnknownComponentClass = false;
-        $this->compilerOptions->ignoreDirectives = config('blade.validation.ignore_directives', []);
+        $this->compilerOptions->ignoreDirectives = ValidatorServiceProvider::getIgnoreDirectives();
         $this->compilerOptions->appendCallbacks[] = function (AppendState $state) {
             for ($i = $state->beforeLineNumber; $i <= $state->afterLineNumber; $i++) {
                 $this->sourceMap[$i] = $state->node->position->startLine;
@@ -113,7 +114,7 @@ class PhpSyntaxValidator
     public function checkString(string $content, ?int $originalLine = null): PhpSyntaxValidationResult
     {
         return $this->checkDocument(
-            Document::fromText($content, documentOptions: new DocumentOptions(ignoreDirectives: config('blade.validation.ignore_directives', []))), $originalLine
+            Document::fromText($content, documentOptions: new DocumentOptions(ignoreDirectives: ValidatorServiceProvider::getIgnoreDirectives())), $originalLine
         );
     }
 

--- a/src/Validation/Validators/ComponentParameterNameSpacingValidator.php
+++ b/src/Validation/Validators/ComponentParameterNameSpacingValidator.php
@@ -19,7 +19,7 @@ class ComponentParameterNameSpacingValidator extends AbstractNodeValidator
      * However, the following example would:
      *    `<x-profile message = "The message" />`
      *
-     * @param  AbstractNode  $node The node to test.
+     * @param  AbstractNode  $node  The node to test.
      */
     public function validate(AbstractNode $node): ValidationResult|array|null
     {

--- a/src/Validation/Validators/ComponentShorthandVariableParameterValidator.php
+++ b/src/Validation/Validators/ComponentShorthandVariableParameterValidator.php
@@ -19,7 +19,7 @@ class ComponentShorthandVariableParameterValidator extends AbstractNodeValidator
      * - Potential typos in shorthand variable syntax; i.e., `$:variable` instead of `:$variable`
      * - Explicitly assigning a value to a shorthand variable; i.e., `:$variable="value"`
      *
-     * @param  AbstractNode  $node The node to validate.
+     * @param  AbstractNode  $node  The node to validate.
      */
     public function validate(AbstractNode $node): ValidationResult|array|null
     {

--- a/src/Validation/Validators/Concerns/AcceptsCustomDirectives.php
+++ b/src/Validation/Validators/Concerns/AcceptsCustomDirectives.php
@@ -12,7 +12,7 @@ trait AcceptsCustomDirectives
     /**
      * Sets the custom directive names.
      *
-     * @param  string[]  $directives The directive names.
+     * @param  string[]  $directives  The directive names.
      */
     public function setCustomDirectives(array $directives): void
     {

--- a/src/Validation/Validators/Concerns/CanIgnoreDirectives.php
+++ b/src/Validation/Validators/Concerns/CanIgnoreDirectives.php
@@ -16,7 +16,7 @@ trait CanIgnoreDirectives
     /**
      * Sets the list of directive names a validator instance should ignore.
      *
-     * @param  string[]  $directives The directive names.
+     * @param  string[]  $directives  The directive names.
      */
     public function setIgnoreDirectives(array $directives): void
     {
@@ -26,7 +26,7 @@ trait CanIgnoreDirectives
     /**
      * Tests if the provided directive should be ignored by the validator.
      *
-     * @param  DirectiveNode  $directive The directive.
+     * @param  DirectiveNode  $directive  The directive.
      */
     protected function shouldIgnore(DirectiveNode $directive): bool
     {

--- a/src/Validation/Validators/DebugDirectiveValidator.php
+++ b/src/Validation/Validators/DebugDirectiveValidator.php
@@ -24,7 +24,7 @@ class DebugDirectiveValidator extends AbstractNodeValidator
     /**
      * Tests if the node is a directive node, and is considered a "debug" directive.
      *
-     * @param  AbstractNode  $node The node to validate.
+     * @param  AbstractNode  $node  The node to validate.
      */
     public function validate(AbstractNode $node): ValidationResult|array|null
     {

--- a/src/Validation/Validators/DirectiveArgumentSpacingValidator.php
+++ b/src/Validation/Validators/DirectiveArgumentSpacingValidator.php
@@ -22,7 +22,7 @@ class DirectiveArgumentSpacingValidator extends AbstractNodeValidator
     /**
      * Sets the number of expected spaces between directives and arguments.
      *
-     * @param  int  $spaces The required spaces.
+     * @param  int  $spaces  The required spaces.
      */
     public function setExpectedSpacing(int $spaces): void
     {

--- a/src/Validation/Validators/Documents/InvalidPhpDocumentValidator.php
+++ b/src/Validation/Validators/Documents/InvalidPhpDocumentValidator.php
@@ -12,7 +12,7 @@ class InvalidPhpDocumentValidator extends AbstractDocumentValidator
     /**
      * Attempts to detect any invalid PHP syntax in the provided document.
      *
-     * @param  Document  $document The document instance.
+     * @param  Document  $document  The document instance.
      */
     public function validate(Document $document): ?ValidationResult
     {

--- a/src/Validation/Workspaces/PhpStanWrapper.php
+++ b/src/Validation/Workspaces/PhpStanWrapper.php
@@ -25,7 +25,7 @@ class PhpStanWrapper
     /**
      * Sets the directory path where blade files will be compiled to.
      *
-     * @param  string  $directory The directory path.
+     * @param  string  $directory  The directory path.
      * @return $this
      */
     public function setDirectory(string $directory): PhpStanWrapper
@@ -55,7 +55,7 @@ class PhpStanWrapper
     /**
      * Runs analysis on the compiled output of all documents within the provided workspace.
      *
-     * @param  Workspace  $workspace The workspace instance.
+     * @param  Workspace  $workspace  The workspace instance.
      *
      * @throws CompilationException
      * @throws UnsupportedNodeException

--- a/src/Workspaces/Concerns/CompilesWorkspace.php
+++ b/src/Workspaces/Concerns/CompilesWorkspace.php
@@ -63,7 +63,7 @@ trait CompilesWorkspace
      * PathFormatter implementations are used to determine
      * what the final output file paths look like.
      *
-     * @param  PathFormatter  $formatter The path formatter.
+     * @param  PathFormatter  $formatter  The path formatter.
      */
     public function withPathFormatter(PathFormatter $formatter): Workspace
     {
@@ -87,7 +87,7 @@ trait CompilesWorkspace
     /**
      * Sets the workspace compiler options.
      *
-     * @param  DocumentCompilerOptions  $options The compiler options.
+     * @param  DocumentCompilerOptions  $options  The compiler options.
      */
     public function withCompilerOptions(DocumentCompilerOptions $options): Workspace
     {
@@ -120,6 +120,7 @@ trait CompilesWorkspace
 
         $options = new DocumentCompilerOptions();
         $options->throwExceptionOnUnknownComponentClass = false;
+        $options->ignoreDirectives = config('blade.validation.ignore_directives', []);
 
         return $options;
     }
@@ -127,7 +128,7 @@ trait CompilesWorkspace
     /**
      * Compiles all discovered Blade templates within the workspace.
      *
-     * @param  string  $outputDirectory Where to store compiled files.
+     * @param  string  $outputDirectory  Where to store compiled files.
      *
      * @throws CompilationException
      * @throws UnsupportedNodeException
@@ -176,8 +177,8 @@ trait CompilesWorkspace
     /**
      * Retrieves the original Blade template line number for the given compiled PHP line.
      *
-     * @param  string  $docPath The compiled path.
-     * @param  int  $phpLine The target PHP line.
+     * @param  string  $docPath  The compiled path.
+     * @param  int  $phpLine  The target PHP line.
      */
     public function getSourceLine(string $docPath, int $phpLine): ?int
     {
@@ -194,7 +195,7 @@ trait CompilesWorkspace
     /**
      * Retrieves a Document instance using the provided compiled path name.
      *
-     * @param  string  $path The compiled path.
+     * @param  string  $path  The compiled path.
      */
     public function getCompiledDocument(string $path): ?Document
     {

--- a/src/Workspaces/Concerns/CompilesWorkspace.php
+++ b/src/Workspaces/Concerns/CompilesWorkspace.php
@@ -120,7 +120,7 @@ trait CompilesWorkspace
 
         $options = new DocumentCompilerOptions();
         $options->throwExceptionOnUnknownComponentClass = false;
-        $options->ignoreDirectives = config('blade.validation.ignore_directives', []);
+        $options->ignoreDirectives = $this->ignoreDirectives;
 
         return $options;
     }

--- a/src/Workspaces/Concerns/ProxiesDocumentCalls.php
+++ b/src/Workspaces/Concerns/ProxiesDocumentCalls.php
@@ -22,7 +22,7 @@ trait ProxiesDocumentCalls
     /**
      * Returns all directives with the provided name in the workspace.
      *
-     * @param  string  $name The directive name to search
+     * @param  string  $name  The directive name to search
      */
     public function findDirectivesByName(string $name): NodeCollection
     {
@@ -167,7 +167,7 @@ trait ProxiesDocumentCalls
      * This method will return *all* component tags that match the
      * provided name, including closing tags.
      *
-     * @param  string  $tagName The tag name to filter on.
+     * @param  string  $tagName  The tag name to filter on.
      */
     public function findComponentsByTagName(string $tagName): NodeCollection
     {
@@ -185,7 +185,7 @@ trait ProxiesDocumentCalls
     /**
      * Tests if the workspace contains a directive with the provided name.
      *
-     * @param  string  $name The directive name.
+     * @param  string  $name  The directive name.
      */
     public function hasDirective(string $name): bool
     {
@@ -195,7 +195,7 @@ trait ProxiesDocumentCalls
     /**
      * Finds all nodes of the provided type.
      *
-     * @param  string  $type The type to search.
+     * @param  string  $type  The type to search.
      */
     public function allOfType(string $type): NodeCollection
     {
@@ -205,7 +205,7 @@ trait ProxiesDocumentCalls
     /**
      * Finds all nodes that are not of the provided type.
      *
-     * @param  string  $type The type to search.
+     * @param  string  $type  The type to search.
      */
     public function allNotOfType(string $type): NodeCollection
     {
@@ -215,7 +215,7 @@ trait ProxiesDocumentCalls
     /**
      * Tests if the workspace contains any node of the provided type.
      *
-     * @param  string  $type The desired type.
+     * @param  string  $type  The desired type.
      */
     public function hasAnyOfType(string $type): bool
     {

--- a/src/Workspaces/Concerns/ValidatesWorkspaces.php
+++ b/src/Workspaces/Concerns/ValidatesWorkspaces.php
@@ -51,7 +51,7 @@ trait ValidatesWorkspaces
     /**
      * Adds a single node validator instance to the internal `BladeValidator` instance.
      *
-     * @param  AbstractNodeValidator  $validator The node validator.
+     * @param  AbstractNodeValidator  $validator  The node validator.
      */
     public function addValidator(AbstractNodeValidator $validator): Workspace
     {
@@ -63,7 +63,7 @@ trait ValidatesWorkspaces
     /**
      * Adds a single document validator instance to the internal `BladeValidator` instance.
      *
-     * @param  AbstractDocumentValidator  $validator The document validator.
+     * @param  AbstractDocumentValidator  $validator  The document validator.
      */
     public function addDocumentValidator(AbstractDocumentValidator $validator): Workspace
     {
@@ -75,7 +75,7 @@ trait ValidatesWorkspaces
     /**
      * Adds a validator instance to the internal `BladeValidator` instance.
      *
-     * @param  AbstractNodeValidator  $validator The validator instance.
+     * @param  AbstractNodeValidator  $validator  The validator instance.
      */
     public function withValidator(AbstractNodeValidator $validator): Workspace
     {
@@ -87,7 +87,7 @@ trait ValidatesWorkspaces
     /**
      * Adds a list of validator instances to the internal `BladeValidator` instance.
      *
-     * @param  AbstractNodeValidator[]  $validators The validator instances.
+     * @param  AbstractNodeValidator[]  $validators  The validator instances.
      */
     public function withValidators(array $validators): Workspace
     {

--- a/src/Workspaces/Workspace.php
+++ b/src/Workspaces/Workspace.php
@@ -10,6 +10,7 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 use Stillat\BladeParser\Contracts\PathFormatter;
 use Stillat\BladeParser\Document\Document;
+use Stillat\BladeParser\Document\DocumentOptions;
 use Stillat\BladeParser\Errors\BladeError;
 use Stillat\BladeParser\Support\Utilities\Paths;
 use Stillat\BladeParser\Workspaces\Concerns\CompilesWorkspace;
@@ -69,6 +70,8 @@ class Workspace
      */
     protected array $workspaceDirectories = [];
 
+    protected array $ignoreDirectives = [];
+
     public function __construct()
     {
         $this->withPathFormatter(new TempPathFormatter);
@@ -89,11 +92,18 @@ class Workspace
         return count($this->filePaths);
     }
 
+    public function ignoreDirectives(array $directives): Workspace
+    {
+        $this->ignoreDirectives = $directives;
+
+        return $this;
+    }
+
     /**
      * Recursively adds all Blade templates to the workspace
      * discovered within the provided directory.
      *
-     * @param  string  $directory The path.
+     * @param  string  $directory  The path.
      * @return $this
      */
     public function addDirectory(string $directory): Workspace
@@ -125,7 +135,7 @@ class Workspace
      * configured Blade extension, the file
      * will *not* be added to the workspace.
      *
-     * @param  string  $path The file path.
+     * @param  string  $path  The file path.
      * @return $this
      */
     public function addFile(string $path): Workspace
@@ -142,7 +152,7 @@ class Workspace
             $this->workspaceDirectories[] = $dirName;
         }
 
-        $document = Document::fromText(file_get_contents($path), $path);
+        $document = Document::fromText(file_get_contents($path), $path, [], new DocumentOptions(ignoreDirectives: $this->ignoreDirectives));
 
         if ($this->shouldResolveStructures) {
             $document->resolveStructures();

--- a/tests/Compiler/BladeComponentTagCompilerTest.php
+++ b/tests/Compiler/BladeComponentTagCompilerTest.php
@@ -1048,6 +1048,31 @@ EXP;
         $this->assertSame(StringUtilities::normalizeLineEndings($expected), StringUtilities::normalizeLineEndings($result));
     }
 
+    public function testEchoInsideComponentParameter()
+    {
+        $blade = <<<'EOT'
+<x-input-with-slot>
+    <x-slot:input for="name" value="{{ __('Token Name') }}">Test</x-slot:input>
+</x-input-with-slot>
+EOT;
+
+        $expected = <<<'EXP'
+##BEGIN-COMPONENT-CLASS##@component('Stillat\BladeParser\Tests\Compiler\InputWithSlot', 'input-with-slot', [])
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag && $constructor = (new ReflectionClass(Stillat\BladeParser\Tests\Compiler\InputWithSlot::class))->getConstructor()): ?>
+<?php $attributes = $attributes->except(collect($constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php $component->withAttributes([]); ?>
+     @slot('input', null, ['for' => 'name','value' => ''.e(__('Token Name')).'']) Test @endslot
+ @endComponentClass##END-COMPONENT-CLASS##
+EXP;
+
+        $result = $this->compiler([
+            'input-with-slot' => InputWithSlot::class,
+        ])->compile($blade);
+
+        $this->assertSame(StringUtilities::normalizeLineEndings($expected), StringUtilities::normalizeLineEndings($result));
+    }
+
     protected function mockViewFactory($existsSucceeds = true)
     {
         $container = new Container;


### PR DESCRIPTION
This PR improves the out-of-box experience with the document validator:

* Resolves an issue where custom Blade component compilers would not be used when compiling documents
* Corrects an issue preventing some component tag parameters from being compiled succesfully

In addition, this PR makes the following changes:

* The `ignore_directives` validation configuration option will now be used to disable parsing and compilation across all validators, for consistency
* Adds the `livewire` directive to the list of ignored directives to prevent users from having to add it each time (due to some lifecycle items)