### PR TITLE
`@parent` directive does not require arguments

### DIFF
--- a/src/Compiler/Concerns/CompilesLayouts.php
+++ b/src/Compiler/Concerns/CompilesLayouts.php
@@ -45,7 +45,7 @@ trait CompilesLayouts
         return "<?php \$__env->startSection{$this->getDirectiveArgs($node)}; ?>";
     }
 
-    #[CompilesDirective(StructureType::Terminator, ArgumentRequirement::Required)]
+    #[CompilesDirective(StructureType::Terminator, ArgumentRequirement::NoArguments)]
     protected function compileParent(): string
     {
         $escapedLastSection = strtr($this->lastSection, ['\\' => '\\\\', "'" => "\\'"]);


### PR DESCRIPTION
> [BLADE_V013] Required arguments missing for [@parent] on line 4

@parent directive is just a placeholder that does not have any arguments.  I feel the need for tests against official documentation, but the official documentation is more focused on use cases rather than specifications, so there's currently no clear guidance on how to construct tests.

See also:

* https://github.com/laravel/framework/blob/2af985e2c26496f2870535b9079dbb207b1dde9a/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php#L61-L71
* https://laravel.com/docs/10.x/blade#extending-a-layout

~~~
<!-- resources/views/child.blade.php -->

@extends('layouts.app')

@section('title', 'Page Title')

@section('sidebar')
    @parent

    <p>This is appended to the master sidebar.</p>
@endsection

@section('content')
    <p>This is my body content.</p>
@endsection
~~~