### PR TITLE
New AttributeCompiler and some new helper functions

### DIFF
--- a/src/Compiler/CompilerServices/AttributeCompiler.php
+++ b/src/Compiler/CompilerServices/AttributeCompiler.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Stillat\BladeParser\Compiler\CompilerServices;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Str;
+use Stillat\BladeParser\Nodes\Components\ComponentNode;
+use Stillat\BladeParser\Nodes\Components\ParameterNode;
+use Stillat\BladeParser\Nodes\Components\ParameterType;
+
+class AttributeCompiler
+{
+    protected array $attributeWrapCallbacks = [];
+
+    protected string $escapedParameterPrefix = '';
+
+    public function prefixEscapedParametersWith(string $prefix): static
+    {
+        $this->escapedParameterPrefix = $prefix;
+
+        return $this;
+    }
+
+    public function wrapResultIn(string|array $attribute, callable $callback): static
+    {
+        if (! is_array($attribute)) {
+            $attribute = [$attribute];
+        }
+
+        foreach ($attribute as $attributeName) {
+            $this->attributeWrapCallbacks[$attributeName] = $callback;
+        }
+
+        return $this;
+    }
+
+    protected function applyWraps(string $attribute, string $value): string
+    {
+        if (! array_key_exists($attribute, $this->attributeWrapCallbacks)) {
+            return $value;
+        }
+
+        return call_user_func($this->attributeWrapCallbacks[$attribute], $value);
+    }
+
+    protected function getParamValue(string $value): string
+    {
+        return Str::replace("'", "\\'", $value);
+    }
+
+    protected function toArraySyntax(string $name, string $value, bool $isString = true): string
+    {
+        if ($isString) {
+            $value = "'{$value}'";
+        }
+
+        $value = $this->applyWraps($name, $value);
+
+        return "'{$name}'=>{$value}";
+    }
+
+    protected function compileAttributeEchos(string $attributeString): string
+    {
+        $value = Blade::compileEchos($attributeString);
+
+        $value = $this->escapeSingleQuotesOutsideOfPhpBlocks($value);
+
+        $value = str_replace('<?php echo ', '\'.', $value);
+
+        return str_replace('; ?>', '.\'', $value);
+    }
+
+    protected function escapeSingleQuotesOutsideOfPhpBlocks(string $value): string
+    {
+        return collect(token_get_all($value))->map(function ($token) {
+            if (! is_array($token)) {
+                return $token;
+            }
+
+            return $token[0] === T_INLINE_HTML
+                ? str_replace("'", "\\'", $token[1])
+                : $token[1];
+        })->implode('');
+    }
+
+    public function compileComponent(ComponentNode $component): string
+    {
+        return $this->compile($component->parameters);
+    }
+
+    public function compile(array $parameters): string
+    {
+        return '['.implode(',', $this->toCompiledArray($parameters)).']';
+    }
+
+    /**
+     * @param  ParameterNode[]  $parameters
+     */
+    public function toCompiledArray(array $parameters): array
+    {
+        if (count($parameters) === 0) {
+            return [];
+        }
+
+        $compiledParameters = [];
+
+        foreach ($parameters as $parameter) {
+            if ($parameter->type == ParameterType::Parameter) {
+                $compiledParameters[] = $this->toArraySyntax($parameter->name, $this->getParamValue($parameter->value));
+            } elseif ($parameter->type == ParameterType::DynamicVariable) {
+                $compiledParameters[] = $this->toArraySyntax($parameter->materializedName, $parameter->value, false);
+            } elseif ($parameter->type == ParameterType::ShorthandDynamicVariable) {
+                $compiledParameters[] = $this->toArraySyntax($parameter->materializedName, $parameter->value, false);
+            } elseif ($parameter->type == ParameterType::EscapedParameter) {
+                $compiledParameters[] = $this->toArraySyntax($this->escapedParameterPrefix.$parameter->materializedName, $parameter->value);
+            } elseif ($parameter->type == ParameterType::Attribute) {
+                $compiledParameters[] = $this->toArraySyntax($parameter->materializedName, 'true', false);
+            } elseif ($parameter->type == ParameterType::InterpolatedValue) {
+                $compiledParameters[] = $this->toArraySyntax($parameter->materializedName, "'".$this->compileAttributeEchos($parameter->value)."'", false);
+            }
+        }
+
+        return $compiledParameters;
+    }
+}

--- a/src/Parser/DocumentParser.php
+++ b/src/Parser/DocumentParser.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Stillat\BladeParser\Compiler\CompilerServices\CoreDirectiveRetriever;
 use Stillat\BladeParser\Compiler\CompilerServices\LiteralContentHelpers;
 use Stillat\BladeParser\Compiler\CompilerServices\StringUtilities;
+use Stillat\BladeParser\Document\Document;
 use Stillat\BladeParser\Document\Structures\DirectiveClosingAnalyzer;
 use Stillat\BladeParser\Errors\BladeError;
 use Stillat\BladeParser\Errors\ConstructContext;
@@ -179,6 +180,18 @@ class DocumentParser extends AbstractParser
         $this->ignoreDirectives = $directives;
 
         return $this;
+    }
+
+    public function toDocument(bool $resolveStructures = true): Document
+    {
+        $document = new Document;
+        $document->syncFromParser($this);
+
+        if ($resolveStructures) {
+            $document->resolveStructures();
+        }
+
+        return $document;
     }
 
     /**
@@ -603,6 +616,13 @@ class DocumentParser extends AbstractParser
         $this->components += 1;
 
         return $componentNode;
+    }
+
+    public function parseTemplate(string $document): static
+    {
+        $this->parse($document);
+
+        return $this;
     }
 
     /**

--- a/tests/CompilerServices/AttributeCompilerTest.php
+++ b/tests/CompilerServices/AttributeCompilerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+uses(\Stillat\BladeParser\Tests\ParserTestCase::class);
+use Stillat\BladeParser\Compiler\CompilerServices\AttributeCompiler;
+use Stillat\BladeParser\Parser\DocumentParser;
+
+beforeEach(function () {
+    $this->attributeCompiler = new AttributeCompiler;
+    $template = <<<'TEMAPLTE'
+<t:component
+  parameter="content"
+  :binding="$theVariable"
+  :$shortHand
+  ::escaped="true"
+  just-an-attribute
+  interpolated="{{ $value }}"
+/>
+TEMAPLTE;
+
+    $this->parameters = (new DocumentParser)
+        ->onlyParseComponents()
+        ->registerCustomComponentTags(['t'])
+        ->parseTemplate($template)
+        ->toDocument()
+        ->getComponents()
+        ->first()
+        ->parameters;
+});
+
+test('it compiles attributes', function () {
+    $expected = <<<'COMPILED'
+['parameter'=>'content','binding'=>$theVariable,'short-hand'=>$shortHand,':escaped'=>'true','just-an-attribute'=>true,'interpolated'=>''.e($value).'']
+COMPILED;
+
+    expect($this->attributeCompiler->compile($this->parameters))->toBe($expected);
+});
+
+test('it can prefix escaped parameters', function () {
+    $this->attributeCompiler->prefixEscapedParametersWith('attr:');
+    $expected = <<<'COMPILED'
+['parameter'=>'content','binding'=>$theVariable,'short-hand'=>$shortHand,'attr::escaped'=>'true','just-an-attribute'=>true,'interpolated'=>''.e($value).'']
+COMPILED;
+
+    expect($this->attributeCompiler->compile($this->parameters))->toBe($expected);
+});
+
+test('it can wrap param content in a callback', function () {
+    $this->attributeCompiler->wrapResultIn(['binding', 'interpolated'], function ($value) {
+        return "customFunctionToUse({$value})";
+    });
+
+    $expected = <<<'COMPILED'
+['parameter'=>'content','binding'=>customFunctionToUse($theVariable),'short-hand'=>$shortHand,':escaped'=>'true','just-an-attribute'=>true,'interpolated'=>customFunctionToUse(''.e($value).'')]
+COMPILED;
+
+    expect($this->attributeCompiler->compile($this->parameters))->toBe($expected);
+});


### PR DESCRIPTION
## New `AttributeCompiler`

The `AttributeCompiler` is a new compiler service that can be used to compile attributes/parameters on a parsed `ComponentNode`. The `AttributeCompiler` implementation will use the core Laravel compiler for content that contains interpolated values.

Usage:

```php
<?php

use Stillat\BladeParser\Parser\DocumentParser;
use Stillat\BladeParser\Compiler\CompilerServices\AttributeCompiler;

$template = <<<'TEMPLATE'
<prefix:component
  parameter="content"
  :binding="$theVariable"
/>
TEMPLATE;

$params = (new DocumentParser)
        ->onlyParseComponents()
        ->registerCustomComponentTags(['prefix'])
        ->parseTemplate($template)
        ->toDocument()
        ->getComponents()
        ->first()
        ->parameters;

$compiler = new AttributeCompiler;
$result = $compiler->compile($params);
```

After compilation, `$result` would contain the following:

```
['parameter'=>'content','binding'=>$theVariable]
```