### PR TITLE
add license to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "stillat/blade-parser",
+    "license": "MIT",
     "autoload": {
         "psr-4": {
             "Stillat\\BladeParser\\": "src"


### PR DESCRIPTION
Hi! We check the licences of our packages in our CI and get a warning¹ because no licence is detected. 😅 

Note that this change would also require a release to reach [Packagist](https://packagist.org/packages/stillat/blade-parser).

---

¹ `There is no license information available for the latest version (v1.10.1) of this package.`