### PR TITLE
Supports Laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,15 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.1
           - laravel: 12.*
             php: 8.2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,12 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:
+          - laravel: 10.*
+            php: 8.4
           - laravel: 12.*
             php: 8.2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [9.*, 10.*, 11.*, 12.*]
+        laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.2, 8.3]
         laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,16 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [9.*, 10.*, 11.*]
+        laravel: [9.*, 10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:
           - laravel: 11.*
             php: 8.1
+          - laravel: 12.*
+            php: 8.1
+          - laravel: 12.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,14 +40,6 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
-      - name: Set PHP 8 Mockery
-        uses: nick-invision/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require "mockery/mockery >=1.3.3" --no-interaction --no-update
-        if: matrix.php >= 8.0
-
       - name: Install dependencies
         uses: nick-invision/retry@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ Thumbs.db
 /phpunit.xml
 /.idea
 /.vscode
-.phpunit.result.cache
+.phpunit.cache
 phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "orchestra/testbench": "^9.2 || ^10.0",
         "laravel/pint": "^1.4",
         "brianium/paratest": "*",
-        "pestphp/pest": "^3.7.3"
+        "pestphp/pest": "^3.7.3",
+        "mockery/mockery": ">=1.3.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "php": "^8.1.0",
+        "php": "^8.2.0",
         "laravel/framework": "^11.0 || ^12.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require": {
         "php": "^8.1.0",
-        "laravel/framework": "^9.36 || ^10.0  || ^11.0"
+        "laravel/framework": "^9.36 || ^10.0  || ^11.0 || ^12.0"
     },
     "require-dev": {
         "orchestra/testbench": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "orchestra/testbench": "*",
         "laravel/pint": "^1.4",
         "brianium/paratest": "*",
-        "pestphp/pest": "^2"
+        "pestphp/pest": "^3.7.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     },
     "require": {
         "php": "^8.1.0",
-        "laravel/framework": "^9.36 || ^10.0  || ^11.0 || ^12.0"
+        "laravel/framework": "^11.0 || ^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0 || ^8.14 || ^9.2 || ^10.0",
+        "orchestra/testbench": "^9.2 || ^10.0",
         "laravel/pint": "^1.4",
         "brianium/paratest": "*",
         "pestphp/pest": "^3.7.3"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/framework": "^9.36 || ^10.0  || ^11.0 || ^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "*",
+        "orchestra/testbench": "^7.0 || ^8.14 || ^9.2 || ^10.0",
         "laravel/pint": "^1.4",
         "brianium/paratest": "*",
         "pestphp/pest": "^3.7.3"

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     },
     "require": {
         "php": "^8.2.0",
-        "laravel/framework": "^11.0 || ^12.0"
+        "laravel/framework": "^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.2 || ^10.0",
+        "orchestra/testbench": "^8.14 || ^9.2 || ^10.0",
         "laravel/pint": "^1.4",
         "brianium/paratest": "*",
         "pestphp/pest": "^3.7.3",


### PR DESCRIPTION
This pull requests adds Laravel 12 support to the `blade-parser` package. It also drops support for Laravel 9 and PHP 8.1.