### PR TITLE
Add support for Blade @includeIsolated directive

### DIFF
--- a/src/Compiler/Concerns/CompilesIncludes.php
+++ b/src/Compiler/Concerns/CompilesIncludes.php
@@ -52,4 +52,10 @@ trait CompilesIncludes
 
         return "<?php echo \$__env->first({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']))->render(); ?>";
     }
+
+    #[CompilesDirective(StructureType::Include, ArgumentRequirement::Required)]
+    protected function compileIncludeIsolated(DirectiveNode $node): string
+    {
+        return "<?php echo \$__env->make({$this->getDirectiveArgsInnerContent($node)})->render(); ?>";
+    }
 }

--- a/tests/Compiler/BladeIncludesTest.php
+++ b/tests/Compiler/BladeIncludesTest.php
@@ -30,3 +30,8 @@ test('include firsts are compiled', function () {
     expect($this->compiler->compileString('@includeFirst(["one", "two"])'))->toBe('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>');
     expect($this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'))->toBe('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>');
 });
+
+test('include isolateds are compiled', function () {
+    expect($this->compiler->compileString('@includeIsolated(\'foo\')'))->toBe('<?php echo $__env->make(\'foo\')->render(); ?>');
+    expect($this->compiler->compileString('@includeIsolated(name(foo))'))->toBe('<?php echo $__env->make(name(foo))->render(); ?>');
+});

--- a/tests/Validation/RecursiveIncludeTest.php
+++ b/tests/Validation/RecursiveIncludeTest.php
@@ -28,3 +28,15 @@ BLADE;
 
     expect($results)->toHaveCount(0);
 });
+
+test('recursive isolated include detects issues', function () {
+    $template = <<<'BLADE'
+@includeIsolated('/tmp/file')
+BLADE;
+    $results = Document::fromText($template, filePath: '/tmp/file.blade.php')
+        ->addValidator(new RecursiveIncludeValidator)
+        ->validate()->getValidationErrors();
+
+    expect($results)->toHaveCount(1);
+    expect($results[0]->message)->toBe("Possible infinite recursion detected near [@includeIsolated('/tmp/file')]");
+});


### PR DESCRIPTION
Hello, we are currently using this parser to power the official Laravel VS Code extension, and we would like to add support for the Blade `@includeIsolated` directive.